### PR TITLE
feat: Add temperature and timing fields to GarminActivity GraphQL type

### DIFF
--- a/src/schema/typeDefs.ts
+++ b/src/schema/typeDefs.ts
@@ -107,6 +107,11 @@ const typeDefs = `#graphql
     total_distance: Float
     avg_pace: Float
     device_manufacturer: String
+    avg_temperature_c: Int
+    min_temperature_c: Int
+    max_temperature_c: Int
+    total_elapsed_time: Float
+    total_timer_time: Float
     created_at: String
     uploaded_at: String
     track_point_count: Int


### PR DESCRIPTION
## Changes

- Add 5 new fields to `GarminActivity` GraphQL type in typeDefs:
  - `avg_temperature_c: Int`
  - `min_temperature_c: Int`
  - `max_temperature_c: Int`
  - `total_elapsed_time: Float`
  - `total_timer_time: Float`

## Context

Pass-through fields from otel-data-api Garmin activity endpoint for the otel-data-ui detail page redesign.