### PR TITLE
chore: add auto-approve workflow, fix shellcheck warnings

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,6 +51,13 @@ git checkout master && git fetch origin && git pull origin master
 git checkout -b feature/my-feature
 ```
 
+**ALWAYS rebase feature branches onto the latest protected branch before creating a PR:**
+
+```bash
+# For feature branches only (do NOT rebase the shared develop branch):
+git fetch origin master && git rebase origin/master
+```
+
 ### Daily Workflow
 
 1. **ALWAYS** start from `develop` or create a feature branch
@@ -59,8 +66,10 @@ git checkout -b feature/my-feature
 4. Run `npm run dev` for development server
 5. Run `npm run lint:all` before commit
 6. Commit and push to `develop` or `feature/*` branch
-7. Create PR to `master` when ready for deployment
-8. **NEVER**: `git push origin master` or commit directly to master
+7. **For feature branches**: rebase onto latest `master` before PR:
+   `git fetch origin master && git rebase origin/master`
+8. Create PR to `master` when ready for deployment
+9. **NEVER**: `git push origin master` or commit directly to master
 
 ## Writing Code
 

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,21 @@
+name: Auto Approve
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    name: Auto Approve Bot PRs
+    runs-on: ubuntu-latest
+    if: >-
+      github.actor == 'renovate[bot]' ||
+      github.actor == 'dependabot[bot]'
+    steps:
+      - name: Auto approve
+        uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Get build info
         id: build_info
         run: |
-          echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+          echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
           BRANCH_NAME="${GITHUB_REF_NAME}"
           SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | sed 's/[\/]/-/g' | sed 's/[^a-zA-Z0-9._-]//g' | tr '[:upper:]' '[:lower:]')
-          echo "branch_sanitized=$SANITIZED_BRANCH" >> $GITHUB_OUTPUT
+          echo "branch_sanitized=$SANITIZED_BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Determine version tag
         id: version
@@ -67,12 +67,12 @@ jobs:
 
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
             VERSION="${BASE_VERSION}.${{ github.run_number }}"
-            echo "version=${VERSION}" >> $GITHUB_OUTPUT
-            echo "is_main=true" >> $GITHUB_OUTPUT
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "is_main=true" >> "$GITHUB_OUTPUT"
           else
             VERSION="${BASE_VERSION}.${{ github.run_number }}-${BRANCH}"
-            echo "version=${VERSION}" >> $GITHUB_OUTPUT
-            echo "is_main=false" >> $GITHUB_OUTPUT
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "is_main=false" >> "$GITHUB_OUTPUT"
           fi
           echo "Version: ${VERSION}"
 
@@ -107,11 +107,11 @@ jobs:
         id: push
         run: |
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/master" ]]; then
-            echo "should_push=true" >> $GITHUB_OUTPUT
+            echo "should_push=true" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.push_image }}" == "true" ]]; then
-            echo "should_push=true" >> $GITHUB_OUTPUT
+            echo "should_push=true" >> "$GITHUB_OUTPUT"
           else
-            echo "should_push=false" >> $GITHUB_OUTPUT
+            echo "should_push=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push
@@ -161,6 +161,7 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           DESCRIPTION="${{ env.IMAGE_NAME }} v${VERSION}"
 
+          # shellcheck disable=SC2016
           QUERY='mutation($version: String!, $entityGuid: EntityGuid!, $commit: String, $user: String, $description: String) {
             changeTrackingCreateDeployment(deployment: {
               version: $version
@@ -196,16 +197,18 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## Docker Build Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Version | \`${{ steps.version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Branch | \`${{ steps.build_info.outputs.branch_sanitized }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Build # | \`${{ github.run_number }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Pushed | \`${{ steps.push.outputs.should_push }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Tags" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Docker Build Summary"
+            echo ""
+            echo "| Property | Value |"
+            echo "|----------|-------|"
+            echo "| Version | \`${{ steps.version.outputs.version }}\` |"
+            echo "| Branch | \`${{ steps.build_info.outputs.branch_sanitized }}\` |"
+            echo "| Build # | \`${{ github.run_number }}\` |"
+            echo "| Pushed | \`${{ steps.push.outputs.should_push }}\` |"
+            echo ""
+            echo "### Tags"
+            echo "\`\`\`"
+            echo "${{ steps.meta.outputs.tags }}"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,9 +38,11 @@ jobs:
       - name: Summary
         if: always()
         run: |
-          echo "## Lint Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ All linting checks completed" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Lint Summary"
+            echo ""
+            echo "✅ All linting checks completed"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   build:
     name: Build Check


### PR DESCRIPTION
## Changes

### New Workflow
- **auto-approve.yml**: Auto-approve Renovate/Dependabot bot PRs using `hmarr/auto-approve-action@v4`

### Shellcheck Fixes (docker.yml)
- **SC2086**: Quote `$GITHUB_OUTPUT` references to prevent word splitting
- **SC2129**: Group summary redirects into single `{ ... } >> "$GITHUB_STEP_SUMMARY"` block
- **SC2016**: Add `shellcheck disable` for GraphQL query string containing `$` variables

### Shellcheck Fixes (lint.yml)
- **SC2129**: Group summary redirects into single block

### Documentation
- Clarify copilot-instructions rebase rule: only feature branches rebase, not shared develop branch

## Testing
- `npm run lint:all` passes (ESLint, markdownlint, shellcheck)
- All workflow YAML validated