### PR TITLE
fix: add --allow-same-version to publish-types workflow

### DIFF
--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -37,7 +37,7 @@ jobs:
           # Extract version from tag (v1.0.8 → 1.0.8)
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           cd ${{ env.TYPES_PKG_DIR }}
-          npm version "$TAG_VERSION" --no-git-tag-version
+          npm version "$TAG_VERSION" --no-git-tag-version --allow-same-version
           echo "Package version: $TAG_VERSION"
 
       - name: Publish to npm


### PR DESCRIPTION
## Problem

The `publish-types.yml` workflow failed on the v1.0.0 release because `npm version "1.0.0"` returns an error when `package.json` already has that version:

```
npm error Version not changed
```

Failed run: https://github.com/stuartshay/otel-data-gateway/actions/runs/22259142506

## Fix

Add `--allow-same-version` flag to `npm version` command. This prevents the error when the tag version matches the existing `package.json` version.

## Impact

After merging, the v1.0.0 release can be re-triggered to publish `@stuartshay/otel-graphql-types` to npm.