### PR TITLE
fix: prevent crash on upstream errors under load

### DIFF
--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -96,7 +96,9 @@ export class OtelDataAPI {
 
     if (cacheTtlMs) {
       inflight.set(cacheKey, request);
-      request.finally(() => inflight.delete(cacheKey));
+      // Swallow rejection on the cleanup chain to prevent unhandled-rejection crashes.
+      // The caller still receives the original rejection from `request`.
+      request.finally(() => inflight.delete(cacheKey)).catch(() => {});
     }
 
     return request;
@@ -104,6 +106,7 @@ export class OtelDataAPI {
 
   private async doFetch<T>(urlString: string, cacheTtlMs?: number): Promise<T> {
     const response = await fetch(urlString, {
+      signal: AbortSignal.timeout(30_000),
       headers: { Accept: 'application/json' },
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,11 @@ import { OtelDataAPI } from './datasources/OtelDataAPI.js';
 import { config } from './config.js';
 import type { GatewayContext } from './resolvers/types.js';
 
+// Safety net: log and survive unhandled rejections instead of crashing
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled rejection:', reason);
+});
+
 const app = express();
 const httpServer = http.createServer(app);
 


### PR DESCRIPTION
## Summary

Fixes a critical crash discovered during k6 stress testing — the gateway process dies with an unhandled promise rejection when the upstream API returns 500 errors under heavy load.

## Changes

### 1. Fix unhandled promise rejection in request deduplication (crash fix)
The `.finally()` cleanup chain on the deduplication promise created a new unhandled promise chain. When the upstream request rejected (e.g., 500 error), this `.finally()` promise also rejected but nobody caught it, causing Node.js v24 to crash the process (`--unhandled-rejections=throw` is the default).

**Fix:** Add `.catch(() => {})` to the cleanup chain so the original rejection still propagates to callers while the cleanup side-effect doesn't crash the process.

### 2. Add 30s upstream request timeout
Added `AbortSignal.timeout(30_000)` to all upstream fetch calls to prevent indefinite hangs when the backend is overwhelmed.

### 3. Add global unhandled rejection handler (safety net)
Added `process.on('unhandledRejection', ...)` in `index.ts` to log and survive any future unhandled rejections instead of crashing.

## Testing

- All 25 unit tests passing
- TypeScript and ESLint clean
- Pre-commit and pre-push checks passing

## Context

During k6 stress testing (10→200 VUs), the pod crashed with:
```
Error: REST API error 500: Internal Server Error
    at OtelDataAPI.doFetch
```
Pod entered CrashLoopBackOff. These fixes ensure the gateway survives upstream failures gracefully.