### PR TITLE
fix(ci): prevent husky failure in update-types workflow

### DIFF
--- a/.github/workflows/update-types.yml
+++ b/.github/workflows/update-types.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           npm pkg set "dependencies.@stuartshay/otel-data-types=${VERSION}"
-          npm install --package-lock-only
+          npm install --package-lock-only --ignore-scripts
           echo "Updated @stuartshay/otel-data-types to ${VERSION}"
 
       - name: Create Pull Request


### PR DESCRIPTION
## Summary
- fix `Update otel-data-types Version` workflow failure in CI
- prevent npm lifecycle scripts from running during lockfile-only update

## Change
- `.github/workflows/update-types.yml`
  - changed `npm install --package-lock-only` to `npm install --package-lock-only --ignore-scripts`

## Why
`repository_dispatch` runs were failing at the update step with `husky: not found`, which blocked automatic PR creation for new `@stuartshay/otel-data-types` releases.

## Validation
- local workflow YAML updated and pushed
- this change is scoped to CI lockfile refresh only

Fixes #27
