### PR TITLE
fix(ci): avoid duplicate auth headers in update-types PR step

### DIFF
--- a/.github/workflows/update-types.yml
+++ b/.github/workflows/update-types.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Determine version
         id: version


### PR DESCRIPTION
## Summary
- fix duplicate `Authorization` header failure in update-types workflow
- prevent checkout from persisting credentials before create-pull-request auth setup

## Change
- `.github/workflows/update-types.yml`
  - `actions/checkout@v6` now uses `persist-credentials: false`

## Why
The workflow run failed in `Create Pull Request` with:
- `remote: Duplicate header: "Authorization"`
- git 400 on `git remote prune origin`

## Validation
- workflow YAML parses correctly
- targeted fix only; no behavior changes outside auth handling in this workflow

Fixes #29
