### PR TITLE
style: format graphql-types index.d.ts codegen output

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -3,17 +3,21 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = {
+  [_ in K]?: never;
+};
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export interface Scalars {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
-  DateTime: { input: string; output: string; }
-  JSON: { input: Record<string, unknown>; output: Record<string, unknown>; }
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  DateTime: { input: string; output: string };
+  JSON: { input: Record<string, unknown>; output: Record<string, unknown> };
 }
 
 /** Per-day aggregate combining OwnTracks location stats and Garmin activity metrics. */
@@ -405,7 +409,6 @@ export interface Query {
   withinReference: WithinReferenceResult;
 }
 
-
 export interface QueryCalculateDistanceArgs {
   from_lat: Scalars['Float']['input'];
   from_lon: Scalars['Float']['input'];
@@ -413,13 +416,11 @@ export interface QueryCalculateDistanceArgs {
   to_lon: Scalars['Float']['input'];
 }
 
-
 export interface QueryDailySummaryArgs {
   date_from?: InputMaybe<Scalars['String']['input']>;
   date_to?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
 }
-
 
 export interface QueryGarminActivitiesArgs {
   date_from?: InputMaybe<Scalars['String']['input']>;
@@ -431,16 +432,13 @@ export interface QueryGarminActivitiesArgs {
   sport?: InputMaybe<Scalars['String']['input']>;
 }
 
-
 export interface QueryGarminActivityArgs {
   activity_id: Scalars['String']['input'];
 }
 
-
 export interface QueryGarminChartDataArgs {
   activity_id: Scalars['String']['input'];
 }
-
 
 export interface QueryGarminTrackPointsArgs {
   activity_id: Scalars['String']['input'];
@@ -451,17 +449,14 @@ export interface QueryGarminTrackPointsArgs {
   sort?: InputMaybe<Scalars['String']['input']>;
 }
 
-
 export interface QueryLocationArgs {
   id: Scalars['Int']['input'];
 }
-
 
 export interface QueryLocationCountArgs {
   date?: InputMaybe<Scalars['String']['input']>;
   device_id?: InputMaybe<Scalars['String']['input']>;
 }
-
 
 export interface QueryLocationsArgs {
   date_from?: InputMaybe<Scalars['String']['input']>;
@@ -473,7 +468,6 @@ export interface QueryLocationsArgs {
   sort?: InputMaybe<Scalars['String']['input']>;
 }
 
-
 export interface QueryNearbyPointsArgs {
   lat: Scalars['Float']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -482,11 +476,9 @@ export interface QueryNearbyPointsArgs {
   source?: InputMaybe<Scalars['String']['input']>;
 }
 
-
 export interface QueryReferenceLocationArgs {
   id: Scalars['Int']['input'];
 }
-
 
 export interface QueryUnifiedGpsArgs {
   date_from?: InputMaybe<Scalars['String']['input']>;
@@ -496,7 +488,6 @@ export interface QueryUnifiedGpsArgs {
   order?: InputMaybe<SortOrder>;
   source?: InputMaybe<Scalars['String']['input']>;
 }
-
 
 export interface QueryWithinReferenceArgs {
   limit?: InputMaybe<Scalars['Int']['input']>;


### PR DESCRIPTION
## Summary

Format `packages/graphql-types/index.d.ts` codegen output to match current Prettier/codegen style:

- Trailing semicolons instead of trailing braces in `Scalars` interface
- Multi-line formatting for `MakeEmpty` and `Incremental` utility types
- Remove extra blank lines between Query arg interfaces

Formatting-only change, no functional impact.