### PR TITLE
feat: Dispatch otel-graphql-types release to otel-data-ui

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -83,6 +83,21 @@ diverge from master.
 5. Post a completion comment on the linked issue/PR confirming the types bump
    PR link, version, and merge status.
 
+### After Types Publish (Required)
+
+⚠️ **ALWAYS verify the downstream dependency PR after publishing
+`@stuartshay/otel-graphql-types`.**
+
+1. Confirm `.github/workflows/publish-types.yml` completed successfully.
+2. Verify a new dependency-update PR is created in `otel-data-ui` (title
+   pattern: `📦 Update @stuartshay/otel-graphql-types to vX.Y.Z`).
+3. Confirm the PR version bump matches the published npm version and CI checks
+   are green.
+4. Link that downstream PR in the originating issue/PR before marking work
+   complete.
+5. If no PR is created or checks fail, open/fix the workflow issue and rerun
+   until a valid PR exists.
+
 ### Release Hygiene Completion (Required)
 
 ⚠️ **ALWAYS complete issue/project hygiene before setting work to Done.**

--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -47,14 +47,36 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Get published version
+        id: types_version
+        run: |
+          PKG_VERSION=$(jq -r '.version' ${{ env.TYPES_PKG_DIR }}/package.json)
+          echo "version=${PKG_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger otel-data-ui types update
+        id: ui_dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITOPS_PAT }}
+          repository: stuartshay/otel-data-ui
+          event-type: otel-graphql-types-release
+          client-payload: '{"version": "${{ steps.types_version.outputs.version }}"}'
+        continue-on-error: true
+
       - name: Summary
         run: |
+          if [ "${{ steps.ui_dispatch.outcome }}" = "success" ]; then
+            DISPATCH_STATUS="✅"
+          else
+            DISPATCH_STATUS="❌ (${{ steps.ui_dispatch.outcome }})"
+          fi
           {
             echo "## npm Package Published"
             echo ""
             echo "| Property | Value |"
             echo "|----------|-------|"
             echo "| Package | \`@stuartshay/otel-graphql-types\` |"
-            echo "| Version | \`${GITHUB_REF_NAME#v}\` |"
+            echo "| Version | \`${{ steps.types_version.outputs.version }}\` |"
             echo "| Release | \`${{ github.event.release.tag_name }}\` |"
+            echo "| UI Dispatch | ${DISPATCH_STATUS} |"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Closes #37

Add `repository_dispatch` step to `publish-types.yml` so that when `@stuartshay/otel-graphql-types` is published to npm, it automatically triggers the `update-types.yml` workflow in `otel-data-ui` to create a dependency update PR.

## Changes

### `publish-types.yml`
- Added `Get published version` step to extract version from built package
- Added `Trigger otel-data-ui types update` step using `peter-evans/repository-dispatch@v3`
  - Event type: `otel-graphql-types-release`
  - Payload: `{"version": "<published_version>"}`
  - `continue-on-error: true` so npm publish succeeds even if dispatch fails
- Updated Summary step to show dispatch status (✅/❌)

### `copilot-instructions.md`
- Added "After Types Publish" section documenting downstream verification requirements

## Pipeline Flow

```
otel-data-gateway release → publish-types.yml → npm publish
                                               → repository_dispatch → otel-data-ui
                                                                        → update-types.yml → PR
```

## Companion PR

- otel-data-ui: stuartshay/otel-data-ui#21 (receiver side)

## Testing

- Mirrors proven pattern from `otel-data-api` → `otel-data-gateway` dispatch
- Can be validated with `workflow_dispatch` on the otel-data-ui side after merge
