### PR TITLE
docs: add PR template with issue closure policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,59 @@
+# Pull Request
+
+## Summary
+
+Refs #<!-- issue number — do NOT use "Closes" or "Fixes" (see below) -->
+
+Describe the change and why it's needed.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change fixing an issue)
+- [ ] New query / mutation
+- [ ] Schema change (breaking or non-breaking)
+- [ ] Data source update
+- [ ] CI/CD pipeline change
+- [ ] Documentation update
+
+## Checklist
+
+- [ ] Read `README.md` and relevant docs
+- [ ] No secrets or credentials committed
+- [ ] Environment variables used for configuration (not hardcoded)
+- [ ] Ran `npm run lint:all` locally (hooks passing)
+- [ ] Ran `npm run test` (tests passing)
+- [ ] Ran `npm run type-check` (no type errors)
+
+## Deployment
+
+- [ ] Does this need [k8s-gitops](https://github.com/stuartshay/k8s-gitops)
+      manifest changes?
+- [ ] Does this publish `@stuartshay/otel-graphql-types`?
+
+## Testing
+
+```bash
+# Commands used to validate changes
+npm run test
+npm run lint:all
+npm run type-check
+```
+
+## Post-Merge Validation
+
+⚠️ **Do NOT use `Closes #` or `Fixes #` in this PR.** Issues must remain open
+until post-deploy acceptance criteria are validated on the cluster.
+
+After this PR merges:
+
+- [ ] Docker image built and pushed (CI)
+- [ ] k8s-gitops deployment PR created and merged
+- [ ] Argo CD synced to cluster
+- [ ] Acceptance criteria validated against deployed behavior
+- [ ] Final validation comment posted on the linked issue
+- [ ] Issue closed manually after all criteria confirmed
+- [ ] If any criterion cannot be validated, reason documented on the issue
+
+## Notes
+
+Any additional context, screenshots, or log output.


### PR DESCRIPTION
## Summary

Refs cross-repo workflow refinement

Adds a standardized PR template that enforces manual issue closure after post-deploy acceptance criteria validation.

## Changes

- **New**: `.github/pull_request_template.md` — PR template with `Refs #` (not `Closes #`), post-merge validation checklist

## Motivation

Issues should not be auto-closed on merge. They must remain open until:
1. PR merges and deploys to the cluster
2. Each acceptance criterion is validated against live behavior
3. Final validation comment is posted with evidence
4. Issue is closed manually

This aligns the workflow across all repos in the homelab ecosystem.