### PR TITLE
feat: Add sync_id correlation and NR custom attributes for Garmin sync mutation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@jest/globals": "^30.3.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
+        "@types/newrelic": "^9.14.8",
         "@types/node": "^25.5.0",
         "cspell": "^9.7.0",
         "eslint": "^9.39.4",
@@ -5138,6 +5139,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/newrelic": {
+      "version": "9.14.8",
+      "resolved": "https://registry.npmjs.org/@types/newrelic/-/newrelic-9.14.8.tgz",
+      "integrity": "sha512-rkOTEVR7Lui4TTEykDUxIxCbFkcI/yw3C8URLOWM84zjuHh9W35RAequHTEvGBbbrLCdn43FVTHMLji4uunDWQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@jest/globals": "^30.3.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
+    "@types/newrelic": "^9.14.8",
     "@types/node": "^25.5.0",
     "cspell": "^9.7.0",
     "eslint": "^9.39.4",

--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { components } from '@stuartshay/otel-data-types';
 import { config } from '../config.js';
 
@@ -22,6 +23,8 @@ interface FetchParams {
   cacheTtlMs?: number;
   /** Non-2xx statuses to handle as structured responses instead of throwing. */
   acceptStatusCodes?: number[];
+  /** Extra HTTP headers to include in the request. */
+  headers?: Record<string, string>;
 }
 
 interface CacheEntry<T> {
@@ -91,6 +94,7 @@ export class OtelDataAPI {
     method = 'GET',
     cacheTtlMs,
     acceptStatusCodes,
+    headers,
   }: FetchParams): Promise<T> {
     const url = this.buildUrl(path, query);
     const urlString = url.toString();
@@ -116,6 +120,7 @@ export class OtelDataAPI {
       cacheKey,
       cacheTtlMs,
       acceptStatusCodes,
+      headers,
     });
 
     if (isCacheable) {
@@ -135,13 +140,14 @@ export class OtelDataAPI {
       cacheKey: string;
       cacheTtlMs?: number;
       acceptStatusCodes?: number[];
+      headers?: Record<string, string>;
     },
   ): Promise<T> {
-    const { method, cacheKey, cacheTtlMs, acceptStatusCodes } = options;
+    const { method, cacheKey, cacheTtlMs, acceptStatusCodes, headers: extraHeaders } = options;
     const response = await fetch(urlString, {
       method,
       signal: AbortSignal.timeout(30_000),
-      headers: { Accept: 'application/json' },
+      headers: { Accept: 'application/json', ...extraHeaders },
     });
 
     if (!response.ok && !(acceptStatusCodes ?? []).includes(response.status)) {
@@ -269,11 +275,26 @@ export class OtelDataAPI {
       lookback?: number;
     }>,
   ): Promise<GarminSyncTriggerResult> {
+    const syncId = randomUUID();
+
+    // Add NR custom attributes for cross-service correlation
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const newrelic = require('newrelic') as typeof import('newrelic');
+      newrelic.addCustomAttributes({
+        'garmin.sync_id': syncId,
+        'garmin.flow': true,
+      });
+    } catch {
+      // NR agent not available — ignore
+    }
+
     const response = await this.fetch<GarminSyncUpstreamResponse>({
       path: '/api/v1/garmin/sync',
       method: 'POST',
       query: params,
       acceptStatusCodes: [400, 409],
+      headers: { 'X-Garmin-Sync-Id': syncId },
     });
 
     return {

--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
 import type { components } from '@stuartshay/otel-data-types';
 import { config } from '../config.js';
 
@@ -147,7 +148,7 @@ export class OtelDataAPI {
     const response = await fetch(urlString, {
       method,
       signal: AbortSignal.timeout(30_000),
-      headers: { Accept: 'application/json', ...extraHeaders },
+      headers: { ...extraHeaders, Accept: 'application/json' },
     });
 
     if (!response.ok && !(acceptStatusCodes ?? []).includes(response.status)) {
@@ -279,7 +280,7 @@ export class OtelDataAPI {
 
     // Add NR custom attributes for cross-service correlation
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const require = createRequire(import.meta.url);
       const newrelic = require('newrelic') as typeof import('newrelic');
       newrelic.addCustomAttributes({
         'garmin.sync_id': syncId,

--- a/tests/datasources/OtelDataAPI.test.ts
+++ b/tests/datasources/OtelDataAPI.test.ts
@@ -166,6 +166,44 @@ describe('OtelDataAPI', () => {
     });
   });
 
+  it('forwards X-Garmin-Sync-Id header with a valid UUID on garmin sync', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 'accepted', message: 'ok' }), {
+        status: 202,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const api = new OtelDataAPI('https://example.test');
+
+    await api.triggerGarminSync();
+
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = options.headers as Record<string, string>;
+    expect(headers['X-Garmin-Sync-Id']).toBeDefined();
+    expect(headers['X-Garmin-Sync-Id']).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it('generates a unique sync_id for each garmin sync call', async () => {
+    fetchMock.mockImplementation(() => jsonResponse({ status: 'accepted', message: 'ok' }));
+    const api = new OtelDataAPI('https://example.test');
+
+    await api.triggerGarminSync();
+    await api.triggerGarminSync();
+
+    const firstHeaders = (fetchMock.mock.calls[0] as [string, RequestInit])[1].headers as Record<
+      string,
+      string
+    >;
+    const secondHeaders = (fetchMock.mock.calls[1] as [string, RequestInit])[1].headers as Record<
+      string,
+      string
+    >;
+
+    expect(firstHeaders['X-Garmin-Sync-Id']).not.toBe(secondHeaders['X-Garmin-Sync-Id']);
+  });
+
   it('routes every gateway method to the expected endpoint', async () => {
     const api = new OtelDataAPI('https://example.test');
 


### PR DESCRIPTION
## Summary

Add cross-service correlation to the Garmin sync trigger mutation. Generates a `sync_id` UUID, sets New Relic custom attributes, and forwards `X-Garmin-Sync-Id` header to the downstream REST API.

## Changes

### `src/datasources/OtelDataAPI.ts`
- Import `randomUUID` from `node:crypto`
- Add `headers` field to `FetchParams` interface for extra HTTP headers
- Pass extra headers through `fetch()` and `executeFetch()` methods
- Generate `sync_id` UUID in `triggerGarminSync()`
- Set `garmin.sync_id` and `garmin.flow` NR custom attributes
- Forward `X-Garmin-Sync-Id` header to downstream otel-data-api

### `package.json` / `package-lock.json`
- Install `@types/newrelic` dev dependency for TypeScript type safety

## Cross-Repo Context

Part of the New Relic aggregated logging effort for Garmin Sync Agent:
- stuartshay/otel-agents#40 / PR #41 — garmin-sync agent structured logging
- stuartshay/otel-data-api#70 / PR #71 — REST API sync_id correlation
- stuartshay/otel-data-ui — Browser agent + garmin.flow attribute (issue TBD)
- stuartshay/k8s-gitops — K8s manifest updates (issue TBD)

## Testing

- [x] ESLint, markdownlint, cspell pass (`npm run lint:all`)
- [x] TypeScript type check passes (`npm run type-check`)
- [x] No breaking changes to existing queries

Refs #43