### PR TITLE
fix: Forward auth token through gateway for geocoding trigger

### DIFF
--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -394,7 +394,10 @@ export class OtelDataAPI {
     }>({ path: '/api/v1/geocoding/status', cacheTtlMs: 15_000 });
   }
 
-  async triggerGeocoding(params?: Nullable<{ batch_size?: number; retry_failed?: boolean }>) {
+  async triggerGeocoding(
+    params?: Nullable<{ batch_size?: number; retry_failed?: boolean }>,
+    token?: string,
+  ) {
     const query: Record<string, string | number | undefined | null> = {};
     if (params?.batch_size != null) query.batch_size = params.batch_size;
     if (params?.retry_failed != null) query.retry_failed = String(params.retry_failed);
@@ -402,6 +405,11 @@ export class OtelDataAPI {
       processed: number;
       remaining: number;
       skipped_dedup: number;
-    }>({ path: '/api/v1/geocoding/trigger', method: 'POST', query });
+    }>({
+      path: '/api/v1/geocoding/trigger',
+      method: 'POST',
+      query,
+      ...(token ? { headers: { Authorization: token } } : {}),
+    });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,10 +46,11 @@ app.use(
   cors<cors.CorsRequest>(),
   express.json(),
   expressMiddleware(server, {
-    context: async (): Promise<GatewayContext> => ({
+    context: async ({ req }): Promise<GatewayContext> => ({
       dataSources: {
         otelAPI: new OtelDataAPI(),
       },
+      token: req.headers.authorization,
     }),
   }),
 );

--- a/src/resolvers/geocoding.ts
+++ b/src/resolvers/geocoding.ts
@@ -11,8 +11,8 @@ export const geocodingResolvers: {
   },
 
   Mutation: {
-    triggerGeocoding: async (_parent, args, { dataSources }) => {
-      return dataSources.otelAPI.triggerGeocoding(args);
+    triggerGeocoding: async (_parent, args, { dataSources, token }) => {
+      return dataSources.otelAPI.triggerGeocoding(args, token);
     },
   },
 };

--- a/src/resolvers/types.ts
+++ b/src/resolvers/types.ts
@@ -4,4 +4,5 @@ export interface GatewayContext {
   dataSources: {
     otelAPI: OtelDataAPI;
   };
+  token?: string;
 }

--- a/tests/datasources/OtelDataAPI.test.ts
+++ b/tests/datasources/OtelDataAPI.test.ts
@@ -239,6 +239,36 @@ describe('OtelDataAPI', () => {
     expect(url).toBe('https://example.test/api/v1/geocoding/trigger');
   });
 
+  it('forwards Authorization header when token is provided to triggerGeocoding', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ processed: 10, remaining: 90, skipped_dedup: 0 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const api = new OtelDataAPI('https://example.test');
+
+    await api.triggerGeocoding({ batch_size: 25 }, 'Bearer my-jwt-token');
+
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(options.headers).toMatchObject({ Authorization: 'Bearer my-jwt-token' });
+  });
+
+  it('does not include Authorization header when no token is provided', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ processed: 10, remaining: 90, skipped_dedup: 0 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const api = new OtelDataAPI('https://example.test');
+
+    await api.triggerGeocoding({ batch_size: 25 });
+
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(options.headers).not.toHaveProperty('Authorization');
+  });
+
   it('caches getGeocodingStatus within TTL', async () => {
     fetchMock.mockImplementation(() =>
       jsonResponse({ total_locations: 100, geocoded: 50, coverage_percent: 50.0 }),

--- a/tests/resolvers/resolvers.test.ts
+++ b/tests/resolvers/resolvers.test.ts
@@ -277,10 +277,14 @@ describe('geocoding resolvers', () => {
     const args = { batch_size: 50, retry_failed: true };
     const result = { processed: 50, remaining: 25, skipped_dedup: 5 };
     const ctx = contextWith({ triggerGeocoding: mockAsync(result) });
+    ctx.token = 'Bearer test-token';
 
     const response = await runResolver(geocodingResolvers.Mutation.triggerGeocoding, args, ctx);
 
-    expect(ctx.dataSources.otelAPI.triggerGeocoding).toHaveBeenCalledWith(args);
+    expect(ctx.dataSources.otelAPI.triggerGeocoding).toHaveBeenCalledWith(
+      args,
+      'Bearer test-token',
+    );
     expect(response).toEqual(result);
   });
 });


### PR DESCRIPTION
## Summary

Fixes geocoding authentication error when triggering geocoding from otel-data-ui. The JWT token from Cognito was not being forwarded through the UI → Gateway → API chain.

## Changes

- **`src/resolvers/types.ts`** — Added `token?: string` to `GatewayContext` interface
- **`src/index.ts`** — Updated context factory to extract `req.headers.authorization` and pass as `token` in context
- **`src/resolvers/geocoding.ts`** — Pass `token` from context to `triggerGeocoding()` data source method
- **`src/datasources/OtelDataAPI.ts`** — Accept optional `token` parameter and forward as `Authorization` header to REST API

## Root Cause

Three breaks existed in the auth chain:
1. UI Apollo client had no auth link to attach JWT header
2. Gateway context factory ignored `req.headers.authorization`
3. Data source `triggerGeocoding()` didn't pass auth headers to upstream API

## Testing

- TypeScript compiles clean (`tsc --noEmit` passes)
- Pre-push lint and spell checks pass

Refs stuartshay/otel-data-ui#46