### PR TITLE
fix: increase geocoding trigger timeout to 120s

### DIFF
--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -26,6 +26,8 @@ interface FetchParams {
   acceptStatusCodes?: number[];
   /** Extra HTTP headers to include in the request. */
   headers?: Record<string, string>;
+  /** Abort timeout in milliseconds (default: 30 000). */
+  timeoutMs?: number;
 }
 
 interface CacheEntry<T> {
@@ -96,6 +98,7 @@ export class OtelDataAPI {
     cacheTtlMs,
     acceptStatusCodes,
     headers,
+    timeoutMs,
   }: FetchParams): Promise<T> {
     const url = this.buildUrl(path, query);
     const urlString = url.toString();
@@ -122,6 +125,7 @@ export class OtelDataAPI {
       cacheTtlMs,
       acceptStatusCodes,
       headers,
+      timeoutMs,
     });
 
     if (isCacheable) {
@@ -142,12 +146,20 @@ export class OtelDataAPI {
       cacheTtlMs?: number;
       acceptStatusCodes?: number[];
       headers?: Record<string, string>;
+      timeoutMs?: number;
     },
   ): Promise<T> {
-    const { method, cacheKey, cacheTtlMs, acceptStatusCodes, headers: extraHeaders } = options;
+    const {
+      method,
+      cacheKey,
+      cacheTtlMs,
+      acceptStatusCodes,
+      headers: extraHeaders,
+      timeoutMs,
+    } = options;
     const response = await fetch(urlString, {
       method,
-      signal: AbortSignal.timeout(30_000),
+      signal: AbortSignal.timeout(timeoutMs ?? 30_000),
       headers: { ...extraHeaders, Accept: 'application/json' },
     });
 
@@ -409,6 +421,7 @@ export class OtelDataAPI {
       path: '/api/v1/geocoding/trigger',
       method: 'POST',
       query,
+      timeoutMs: 120_000,
       ...(token ? { headers: { Authorization: token } } : {}),
     });
   }


### PR DESCRIPTION
## Summary

The gateway's default 30s `AbortSignal.timeout` was aborting geocoding batch operations before the API could finish processing all records in the batch. With batch sizes of 100, each requiring a Pelias reverse geocode call plus DB writes, the total time easily exceeds 30s.

## Changes

### `src/datasources/OtelDataAPI.ts`
- Added `timeoutMs` optional parameter to `FetchParams` interface
- Passed `timeoutMs` through `fetch()` → `doFetch()` chain
- Default fetch timeout remains 30s for all other endpoints
- Geocoding trigger (`/api/v1/geocoding/trigger`) uses 120s timeout

## Testing
- All 43 gateway unit tests pass
- TypeScript compiles cleanly
- Tested geocoding trigger via UI — batch completes without abort