### PR TITLE
feat: add exclude_stationary and deduplicate args to unifiedGps query

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -553,6 +553,8 @@ export interface QueryReferenceLocationArgs {
 export interface QueryUnifiedGpsArgs {
   date_from?: InputMaybe<Scalars['String']['input']>;
   date_to?: InputMaybe<Scalars['String']['input']>;
+  deduplicate?: InputMaybe<Scalars['Boolean']['input']>;
+  exclude_stationary?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<SortOrder>;

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -566,6 +566,8 @@ export type QueryReferenceLocationArgs = {
 export type QueryUnifiedGpsArgs = {
   date_from?: InputMaybe<Scalars['String']['input']>;
   date_to?: InputMaybe<Scalars['String']['input']>;
+  deduplicate?: InputMaybe<Scalars['Boolean']['input']>;
+  exclude_stationary?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<SortOrder>;

--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -18,7 +18,7 @@ type GarminSyncUpstreamResponse = Schemas['GarminSyncResponse'] & {
 
 interface FetchParams {
   path: string;
-  query?: Record<string, string | number | undefined | null>;
+  query?: Record<string, string | number | boolean | undefined | null>;
   method?: 'GET' | 'POST';
   /** TTL in milliseconds. When set, responses are cached and deduplicated. */
   cacheTtlMs?: number;
@@ -79,7 +79,10 @@ export class OtelDataAPI {
     this.baseUrl = baseUrl ?? config.otelDataApiUrl;
   }
 
-  private buildUrl(path: string, query?: Record<string, string | number | undefined | null>): URL {
+  private buildUrl(
+    path: string,
+    query?: Record<string, string | number | boolean | undefined | null>,
+  ): URL {
     const url = new URL(path, this.baseUrl);
     if (query) {
       for (const [key, value] of Object.entries(query)) {
@@ -326,6 +329,8 @@ export class OtelDataAPI {
       limit?: number;
       offset?: number;
       order?: string;
+      exclude_stationary?: boolean;
+      deduplicate?: boolean;
     }>,
   ) {
     return this.fetch<Schemas['PaginatedResponse_UnifiedGpsPoint_']>({

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1125,6 +1125,14 @@ type Query {
     Sort direction
     """
     order: SortOrder
+    """
+    Exclude stationary points where speed is zero
+    """
+    exclude_stationary: Boolean
+    """
+    Remove points with duplicate coordinates (rounded to ~11m precision)
+    """
+    deduplicate: Boolean
   ): UnifiedGpsConnection!
 
   """

--- a/tests/datasources/OtelDataAPI.test.ts
+++ b/tests/datasources/OtelDataAPI.test.ts
@@ -75,6 +75,25 @@ describe('OtelDataAPI', () => {
     expect(parsed.searchParams.get('limit')).toBe('5');
   });
 
+  it('serializes boolean query params for unified GPS filters', async () => {
+    const api = new OtelDataAPI('https://example.test');
+
+    await api.getUnifiedGps({
+      source: 'gps',
+      limit: 100,
+      exclude_stationary: true,
+      deduplicate: true,
+    });
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    const parsed = new URL(url);
+
+    expect(parsed.pathname).toBe('/api/v1/gps/unified');
+    expect(parsed.searchParams.get('source')).toBe('gps');
+    expect(parsed.searchParams.get('exclude_stationary')).toBe('true');
+    expect(parsed.searchParams.get('deduplicate')).toBe('true');
+  });
+
   it('throws informative errors when REST API responds with failure', async () => {
     fetchMock.mockResolvedValueOnce(
       new Response('backend failed', {

--- a/tests/resolvers/resolvers.test.ts
+++ b/tests/resolvers/resolvers.test.ts
@@ -195,6 +195,22 @@ describe('gps resolvers', () => {
     expect(ctx.dataSources.otelAPI.getUnifiedGps).toHaveBeenCalledWith({ limit: 2, source: 'gps' });
     expect(ctx.dataSources.otelAPI.getDailySummary).toHaveBeenCalledWith({ limit: 1 });
   });
+
+  it('forwards exclude_stationary and deduplicate args to data source', async () => {
+    const ctx = contextWith({
+      getUnifiedGps: mockAsync({ items: [], total: 0, limit: 100, offset: 0 }),
+    });
+    const args = {
+      limit: 100,
+      source: 'gps',
+      exclude_stationary: true,
+      deduplicate: true,
+    };
+
+    await runResolver(gpsResolvers.Query.unifiedGps, args, ctx);
+
+    expect(ctx.dataSources.otelAPI.getUnifiedGps).toHaveBeenCalledWith(args);
+  });
 });
 
 describe('reference resolvers', () => {


### PR DESCRIPTION
## Summary

Add `exclude_stationary` and `deduplicate` Boolean arguments to the `unifiedGps` GraphQL query, passing them through to the otel-data-api REST endpoint.

## Changes

- `src/schema/schema.graphql` — Added `exclude_stationary: Boolean` and `deduplicate: Boolean` args to `unifiedGps` query
- `src/datasources/OtelDataAPI.ts` — Added boolean params to `getUnifiedGps()` type signature; added `boolean` to query Record type for URL serialization
- `src/__generated__/resolvers-types.ts` — Regenerated codegen types
- `packages/graphql-types/index.d.ts` — Regenerated downstream types package

## Depends On

- stuartshay/otel-data-api#80 (API must be deployed first)