### PR TITLE
feat: add locationDateRange GraphQL query

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -358,9 +358,9 @@ export interface LocationCount {
 export interface LocationDateRange {
   __typename?: 'LocationDateRange';
   /** Latest location timestamp (ISO 8601) */
-  max_date: Scalars['String']['output'];
+  max_date: Scalars['DateTime']['output'];
   /** Earliest location timestamp (ISO 8601) */
-  min_date: Scalars['String']['output'];
+  min_date: Scalars['DateTime']['output'];
 }
 
 /** Full location detail including the original OwnTracks JSON payload. */

--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -354,6 +354,15 @@ export interface LocationCount {
   device_id?: Maybe<Scalars['String']['output']>;
 }
 
+/** Earliest and latest timestamps in the locations table. */
+export interface LocationDateRange {
+  __typename?: 'LocationDateRange';
+  /** Latest location timestamp (ISO 8601) */
+  max_date: Scalars['String']['output'];
+  /** Earliest location timestamp (ISO 8601) */
+  min_date: Scalars['String']['output'];
+}
+
 /** Full location detail including the original OwnTracks JSON payload. */
 export interface LocationDetail {
   __typename?: 'LocationDetail';
@@ -463,6 +472,8 @@ export interface Query {
   location?: Maybe<LocationDetail>;
   /** Get aggregate count of location records with optional filters. */
   locationCount: LocationCount;
+  /** Get the earliest and latest location timestamps. */
+  locationDateRange: LocationDateRange;
   /** Retrieve a paginated list of OwnTracks location records. */
   locations: LocationConnection;
   /** Find GPS points within a radius of a geographic coordinate. */

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -357,9 +357,9 @@ export type LocationCount = {
 export type LocationDateRange = {
   __typename?: 'LocationDateRange';
   /** Latest location timestamp (ISO 8601) */
-  max_date: Scalars['String']['output'];
+  max_date: Scalars['DateTime']['output'];
   /** Earliest location timestamp (ISO 8601) */
-  min_date: Scalars['String']['output'];
+  min_date: Scalars['DateTime']['output'];
 };
 
 /** Full location detail including the original OwnTracks JSON payload. */
@@ -1025,8 +1025,8 @@ export type LocationCountResolvers<ContextType = GatewayContext, ParentType exte
 }>;
 
 export type LocationDateRangeResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['LocationDateRange'] = ResolversParentTypes['LocationDateRange']> = ResolversObject<{
-  max_date?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  min_date?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  max_date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  min_date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
 }>;
 
 export type LocationDetailResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['LocationDetail'] = ResolversParentTypes['LocationDetail']> = ResolversObject<{

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -353,6 +353,15 @@ export type LocationCount = {
   device_id?: Maybe<Scalars['String']['output']>;
 };
 
+/** Earliest and latest timestamps in the locations table. */
+export type LocationDateRange = {
+  __typename?: 'LocationDateRange';
+  /** Latest location timestamp (ISO 8601) */
+  max_date: Scalars['String']['output'];
+  /** Earliest location timestamp (ISO 8601) */
+  min_date: Scalars['String']['output'];
+};
+
 /** Full location detail including the original OwnTracks JSON payload. */
 export type LocationDetail = {
   __typename?: 'LocationDetail';
@@ -464,6 +473,8 @@ export type Query = {
   location?: Maybe<LocationDetail>;
   /** Get aggregate count of location records with optional filters. */
   locationCount: LocationCount;
+  /** Get the earliest and latest location timestamps. */
+  locationDateRange: LocationDateRange;
   /** Retrieve a paginated list of OwnTracks location records. */
   locations: LocationConnection;
   /** Find GPS points within a radius of a geographic coordinate. */
@@ -776,6 +787,7 @@ export type ResolversTypes = ResolversObject<{
   Location: ResolverTypeWrapper<Location>;
   LocationConnection: ResolverTypeWrapper<LocationConnection>;
   LocationCount: ResolverTypeWrapper<LocationCount>;
+  LocationDateRange: ResolverTypeWrapper<LocationDateRange>;
   LocationDetail: ResolverTypeWrapper<LocationDetail>;
   Mutation: ResolverTypeWrapper<Record<PropertyKey, never>>;
   NearbyPoint: ResolverTypeWrapper<NearbyPoint>;
@@ -814,6 +826,7 @@ export type ResolversParentTypes = ResolversObject<{
   Location: Location;
   LocationConnection: LocationConnection;
   LocationCount: LocationCount;
+  LocationDateRange: LocationDateRange;
   LocationDetail: LocationDetail;
   Mutation: Record<PropertyKey, never>;
   NearbyPoint: NearbyPoint;
@@ -1011,6 +1024,11 @@ export type LocationCountResolvers<ContextType = GatewayContext, ParentType exte
   device_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
+export type LocationDateRangeResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['LocationDateRange'] = ResolversParentTypes['LocationDateRange']> = ResolversObject<{
+  max_date?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  min_date?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
 export type LocationDetailResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['LocationDetail'] = ResolversParentTypes['LocationDetail']> = ResolversObject<{
   accuracy?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   address?: Resolver<Maybe<ResolversTypes['GeocodedAddress']>, ParentType, ContextType>;
@@ -1063,6 +1081,7 @@ export type QueryResolvers<ContextType = GatewayContext, ParentType extends Reso
   health?: Resolver<ResolversTypes['HealthStatus'], ParentType, ContextType>;
   location?: Resolver<Maybe<ResolversTypes['LocationDetail']>, ParentType, ContextType, RequireFields<QueryLocationArgs, 'id'>>;
   locationCount?: Resolver<ResolversTypes['LocationCount'], ParentType, ContextType, Partial<QueryLocationCountArgs>>;
+  locationDateRange?: Resolver<ResolversTypes['LocationDateRange'], ParentType, ContextType>;
   locations?: Resolver<ResolversTypes['LocationConnection'], ParentType, ContextType, Partial<QueryLocationsArgs>>;
   nearbyPoints?: Resolver<Array<ResolversTypes['NearbyPoint']>, ParentType, ContextType, RequireFields<QueryNearbyPointsArgs, 'lat' | 'lon'>>;
   ready?: Resolver<ResolversTypes['ReadyStatus'], ParentType, ContextType>;
@@ -1140,6 +1159,7 @@ export type Resolvers<ContextType = GatewayContext> = ResolversObject<{
   Location?: LocationResolvers<ContextType>;
   LocationConnection?: LocationConnectionResolvers<ContextType>;
   LocationCount?: LocationCountResolvers<ContextType>;
+  LocationDateRange?: LocationDateRangeResolvers<ContextType>;
   LocationDetail?: LocationDetailResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   NearbyPoint?: NearbyPointResolvers<ContextType>;

--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -228,6 +228,13 @@ export class OtelDataAPI {
     });
   }
 
+  async getLocationDateRange() {
+    return this.fetch<{ min_date: string; max_date: string }>({
+      path: '/api/v1/locations/date-range',
+      cacheTtlMs: 60_000,
+    });
+  }
+
   // ── Garmin ──────────────────────────────────────────
 
   async getGarminActivities(

--- a/src/resolvers/location.ts
+++ b/src/resolvers/location.ts
@@ -1,7 +1,10 @@
 import type { QueryResolvers } from '../__generated__/resolvers-types.js';
 
 export const locationResolvers: {
-  Query: Pick<QueryResolvers, 'locations' | 'location' | 'devices' | 'locationCount'>;
+  Query: Pick<
+    QueryResolvers,
+    'locations' | 'location' | 'devices' | 'locationCount' | 'locationDateRange'
+  >;
 } = {
   Query: {
     locations: async (_parent, args, { dataSources }) => {
@@ -18,6 +21,10 @@ export const locationResolvers: {
 
     locationCount: async (_parent, args, { dataSources }) => {
       return dataSources.otelAPI.getLocationCount(args);
+    },
+
+    locationDateRange: async (_parent, _args, { dataSources }) => {
+      return dataSources.otelAPI.getLocationDateRange();
     },
   },
 };

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -355,6 +355,20 @@ type LocationCount {
   device_id: String
 }
 
+"""
+Earliest and latest timestamps in the locations table.
+"""
+type LocationDateRange {
+  """
+  Earliest location timestamp (ISO 8601)
+  """
+  min_date: String!
+  """
+  Latest location timestamp (ISO 8601)
+  """
+  max_date: String!
+}
+
 # -------------------------------------------------------
 # Garmin
 # -------------------------------------------------------
@@ -1005,6 +1019,11 @@ type Query {
     """
     device_id: String
   ): LocationCount!
+
+  """
+  Get the earliest and latest location timestamps.
+  """
+  locationDateRange: LocationDateRange!
 
   # Garmin
   """

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -362,11 +362,11 @@ type LocationDateRange {
   """
   Earliest location timestamp (ISO 8601)
   """
-  min_date: String!
+  min_date: DateTime!
   """
   Latest location timestamp (ISO 8601)
   """
-  max_date: String!
+  max_date: DateTime!
 }
 
 # -------------------------------------------------------

--- a/tests/resolvers/resolvers.test.ts
+++ b/tests/resolvers/resolvers.test.ts
@@ -90,11 +90,15 @@ describe('location resolvers', () => {
     expect(response).toBe(result);
   });
 
-  it('delegates detail, devices, and count queries', async () => {
+  it('delegates detail, devices, count, and date-range queries', async () => {
     const ctx = contextWith({
       getLocation: mockAsync({ id: 10 }),
       getDevices: mockAsync([{ device_id: 'iphone' }]),
       getLocationCount: mockAsync({ total: 4 }),
+      getLocationDateRange: mockAsync({
+        min_date: '2025-12-27T00:00:00Z',
+        max_date: '2026-01-15T00:00:00Z',
+      }),
     });
 
     const location = await runResolver(locationResolvers.Query.location, { id: 10 }, ctx);
@@ -104,11 +108,16 @@ describe('location resolvers', () => {
       { device_id: 'iphone' },
       ctx,
     );
+    const dateRange = await runResolver(locationResolvers.Query.locationDateRange, {}, ctx);
 
     expect(ctx.dataSources.otelAPI.getLocation).toHaveBeenCalledWith(10);
     expect(location).toEqual({ id: 10 });
     expect(devices).toEqual([{ device_id: 'iphone' }]);
     expect(count).toEqual({ total: 4 });
+    expect(dateRange).toEqual({
+      min_date: '2025-12-27T00:00:00Z',
+      max_date: '2026-01-15T00:00:00Z',
+    });
   });
 });
 
@@ -317,6 +326,7 @@ describe('resolver index', () => {
         'location',
         'devices',
         'locationCount',
+        'locationDateRange',
         'garminActivities',
         'garminActivity',
         'garminTrackPoints',

--- a/tests/resolvers/resolvers.test.ts
+++ b/tests/resolvers/resolvers.test.ts
@@ -111,6 +111,7 @@ describe('location resolvers', () => {
     const dateRange = await runResolver(locationResolvers.Query.locationDateRange, {}, ctx);
 
     expect(ctx.dataSources.otelAPI.getLocation).toHaveBeenCalledWith(10);
+    expect(ctx.dataSources.otelAPI.getLocationDateRange).toHaveBeenCalled();
     expect(location).toEqual({ id: 10 });
     expect(devices).toEqual([{ device_id: 'iphone' }]);
     expect(count).toEqual({ total: 4 });


### PR DESCRIPTION
Add GraphQL type and query for retrieving the earliest and latest timestamps from the locations table.

## Changes
- Add `LocationDateRange` type to schema (`src/schema/schema.graphql`)
- Add `locationDateRange` resolver (`src/resolvers/location.ts`)
- Add `getLocationDateRange()` datasource method (`src/datasources/OtelDataAPI.ts`)
- Regenerate codegen types
- Add test coverage for new resolver

## Related PRs
- otel-data-api: `feature/locations-date-range` (REST endpoint)
- otel-data-ui PR #55 (consumes the query)