### PR TITLE
feat: Add garminDateRange GraphQL query

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -166,6 +166,15 @@ export interface GarminChartPoint {
   timestamp: Scalars['DateTime']['output'];
 }
 
+/** Earliest and latest timestamps in the Garmin activities table. */
+export interface GarminDateRange {
+  __typename?: 'GarminDateRange';
+  /** Latest Garmin activity timestamp (ISO 8601) */
+  max_date: Scalars['DateTime']['output'];
+  /** Earliest Garmin activity timestamp (ISO 8601) */
+  min_date: Scalars['DateTime']['output'];
+}
+
 /** Result payload returned when triggering an on-demand Garmin sync. */
 export interface GarminSyncTriggerResult {
   __typename?: 'GarminSyncTriggerResult';
@@ -460,6 +469,8 @@ export interface Query {
   garminActivity?: Maybe<GarminActivity>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
   garminChartData: Array<GarminChartPoint>;
+  /** Get the earliest and latest Garmin activity timestamps. */
+  garminDateRange: GarminDateRange;
   /** List all distinct sport types with activity counts. */
   garminSports: Array<SportInfo>;
   /** Retrieve paginated GPS track points for a Garmin activity. */

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -165,6 +165,15 @@ export type GarminChartPoint = {
   timestamp: Scalars['DateTime']['output'];
 };
 
+/** Earliest and latest timestamps in the Garmin activities table. */
+export type GarminDateRange = {
+  __typename?: 'GarminDateRange';
+  /** Latest Garmin activity timestamp (ISO 8601) */
+  max_date: Scalars['DateTime']['output'];
+  /** Earliest Garmin activity timestamp (ISO 8601) */
+  min_date: Scalars['DateTime']['output'];
+};
+
 /** Result payload returned when triggering an on-demand Garmin sync. */
 export type GarminSyncTriggerResult = {
   __typename?: 'GarminSyncTriggerResult';
@@ -461,6 +470,8 @@ export type Query = {
   garminActivity?: Maybe<GarminActivity>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
   garminChartData: Array<GarminChartPoint>;
+  /** Get the earliest and latest Garmin activity timestamps. */
+  garminDateRange: GarminDateRange;
   /** List all distinct sport types with activity counts. */
   garminSports: Array<SportInfo>;
   /** Retrieve paginated GPS track points for a Garmin activity. */
@@ -775,6 +786,7 @@ export type ResolversTypes = ResolversObject<{
   GarminActivity: ResolverTypeWrapper<GarminActivity>;
   GarminActivityConnection: ResolverTypeWrapper<GarminActivityConnection>;
   GarminChartPoint: ResolverTypeWrapper<GarminChartPoint>;
+  GarminDateRange: ResolverTypeWrapper<GarminDateRange>;
   GarminSyncTriggerResult: ResolverTypeWrapper<GarminSyncTriggerResult>;
   GarminTrackPoint: ResolverTypeWrapper<GarminTrackPoint>;
   GarminTrackPointConnection: ResolverTypeWrapper<GarminTrackPointConnection>;
@@ -814,6 +826,7 @@ export type ResolversParentTypes = ResolversObject<{
   GarminActivity: GarminActivity;
   GarminActivityConnection: GarminActivityConnection;
   GarminChartPoint: GarminChartPoint;
+  GarminDateRange: GarminDateRange;
   GarminSyncTriggerResult: GarminSyncTriggerResult;
   GarminTrackPoint: GarminTrackPoint;
   GarminTrackPointConnection: GarminTrackPointConnection;
@@ -919,6 +932,11 @@ export type GarminChartPointResolvers<ContextType = GatewayContext, ParentType e
   speed_kmh?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   temperature_c?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   timestamp?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+}>;
+
+export type GarminDateRangeResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminDateRange'] = ResolversParentTypes['GarminDateRange']> = ResolversObject<{
+  max_date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  min_date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
 }>;
 
 export type GarminSyncTriggerResultResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminSyncTriggerResult'] = ResolversParentTypes['GarminSyncTriggerResult']> = ResolversObject<{
@@ -1075,6 +1093,7 @@ export type QueryResolvers<ContextType = GatewayContext, ParentType extends Reso
   garminActivities?: Resolver<ResolversTypes['GarminActivityConnection'], ParentType, ContextType, Partial<QueryGarminActivitiesArgs>>;
   garminActivity?: Resolver<Maybe<ResolversTypes['GarminActivity']>, ParentType, ContextType, RequireFields<QueryGarminActivityArgs, 'activity_id'>>;
   garminChartData?: Resolver<Array<ResolversTypes['GarminChartPoint']>, ParentType, ContextType, RequireFields<QueryGarminChartDataArgs, 'activity_id'>>;
+  garminDateRange?: Resolver<ResolversTypes['GarminDateRange'], ParentType, ContextType>;
   garminSports?: Resolver<Array<ResolversTypes['SportInfo']>, ParentType, ContextType>;
   garminTrackPoints?: Resolver<ResolversTypes['GarminTrackPointConnection'], ParentType, ContextType, RequireFields<QueryGarminTrackPointsArgs, 'activity_id'>>;
   geocodingStatus?: Resolver<ResolversTypes['GeocodingStatus'], ParentType, ContextType>;
@@ -1148,6 +1167,7 @@ export type Resolvers<ContextType = GatewayContext> = ResolversObject<{
   GarminActivity?: GarminActivityResolvers<ContextType>;
   GarminActivityConnection?: GarminActivityConnectionResolvers<ContextType>;
   GarminChartPoint?: GarminChartPointResolvers<ContextType>;
+  GarminDateRange?: GarminDateRangeResolvers<ContextType>;
   GarminSyncTriggerResult?: GarminSyncTriggerResultResolvers<ContextType>;
   GarminTrackPoint?: GarminTrackPointResolvers<ContextType>;
   GarminTrackPointConnection?: GarminTrackPointConnectionResolvers<ContextType>;

--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -237,6 +237,13 @@ export class OtelDataAPI {
 
   // ── Garmin ──────────────────────────────────────────
 
+  async getGarminDateRange() {
+    return this.fetch<{ min_date: string; max_date: string }>({
+      path: '/api/v1/garmin/date-range',
+      cacheTtlMs: 60_000,
+    });
+  }
+
   async getGarminActivities(
     params?: Nullable<{
       sport?: string;

--- a/src/resolvers/garmin.ts
+++ b/src/resolvers/garmin.ts
@@ -3,11 +3,20 @@ import type { MutationResolvers, QueryResolvers } from '../__generated__/resolve
 export const garminResolvers: {
   Query: Pick<
     QueryResolvers,
-    'garminActivities' | 'garminActivity' | 'garminTrackPoints' | 'garminSports' | 'garminChartData'
+    | 'garminDateRange'
+    | 'garminActivities'
+    | 'garminActivity'
+    | 'garminTrackPoints'
+    | 'garminSports'
+    | 'garminChartData'
   >;
   Mutation: Pick<MutationResolvers, 'triggerGarminSync'>;
 } = {
   Query: {
+    garminDateRange: async (_parent, _args, { dataSources }) => {
+      return dataSources.otelAPI.getGarminDateRange();
+    },
+
     garminActivities: async (_parent, args, { dataSources }) => {
       return dataSources.otelAPI.getGarminActivities(args);
     },

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -509,6 +509,20 @@ type GarminActivityConnection {
 }
 
 """
+Earliest and latest timestamps in the Garmin activities table.
+"""
+type GarminDateRange {
+  """
+  Earliest Garmin activity timestamp (ISO 8601)
+  """
+  min_date: DateTime!
+  """
+  Latest Garmin activity timestamp (ISO 8601)
+  """
+  max_date: DateTime!
+}
+
+"""
 Individual GPS track point within a Garmin activity.
 """
 type GarminTrackPoint {
@@ -1026,6 +1040,11 @@ type Query {
   locationDateRange: LocationDateRange!
 
   # Garmin
+  """
+  Get the earliest and latest Garmin activity timestamps.
+  """
+  garminDateRange: GarminDateRange!
+
   """
   Retrieve a paginated list of Garmin activities.
   """

--- a/tests/datasources/OtelDataAPI.test.ts
+++ b/tests/datasources/OtelDataAPI.test.ts
@@ -327,6 +327,7 @@ describe('OtelDataAPI', () => {
     await api.getNearbyPoints({ lat: 1, lon: 2, radius_meters: 50, limit: 1, source: 'gps' });
     await api.getDistance({ from_lat: 1, from_lon: 2, to_lat: 3, to_lon: 4 });
     await api.getWithinReference('Home', { source: 'gps', limit: 2 });
+    await api.getGarminDateRange();
     await api.getGeocodingStatus();
     await api.triggerGeocoding({ batch_size: 100 });
 
@@ -352,6 +353,7 @@ describe('OtelDataAPI', () => {
       '/api/v1/spatial/nearby',
       '/api/v1/spatial/distance',
       '/api/v1/spatial/within-reference/Home',
+      '/api/v1/garmin/date-range',
       '/api/v1/geocoding/status',
       '/api/v1/geocoding/trigger',
     ]);
@@ -436,6 +438,25 @@ describe('OtelDataAPI', () => {
 
     nowSpy.mockReturnValue(31_000);
     await api.getGarminChartData('ga-1');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    nowSpy.mockRestore();
+  });
+
+  it('caches garminDateRange responses for 60s', async () => {
+    fetchMock.mockImplementation(() =>
+      jsonResponse({ min_date: '2020-01-01T00:00:00Z', max_date: '2026-04-01T00:00:00Z' }),
+    );
+    const api = new OtelDataAPI('https://example.test');
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    nowSpy.mockReturnValue(0);
+    await api.getGarminDateRange();
+    await api.getGarminDateRange();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    nowSpy.mockReturnValue(61_000);
+    await api.getGarminDateRange();
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
     nowSpy.mockRestore();

--- a/tests/resolvers/resolvers.test.ts
+++ b/tests/resolvers/resolvers.test.ts
@@ -175,6 +175,16 @@ describe('garmin resolvers', () => {
     expect(ctx.dataSources.otelAPI.getGarminChartData).toHaveBeenCalledWith('abc');
   });
 
+  it('delegates garminDateRange to datasource', async () => {
+    const result = { min_date: '2020-01-01T00:00:00Z', max_date: '2026-04-01T00:00:00Z' };
+    const ctx = contextWith({ getGarminDateRange: mockAsync(result) });
+
+    const response = await runResolver(garminResolvers.Query.garminDateRange, {}, ctx);
+
+    expect(ctx.dataSources.otelAPI.getGarminDateRange).toHaveBeenCalled();
+    expect(response).toEqual(result);
+  });
+
   it('delegates triggerGarminSync mutation with passthrough args', async () => {
     const args = { window_hours: 48, lookback: null };
     const result = {


### PR DESCRIPTION
## Summary

Add `garminDateRange` GraphQL query that returns min/max dates from the Garmin activities dataset, enabling the UI to set calendar date bounds on the Garmin Activities page.

## Changes

- **`src/schema/schema.graphql`** — Add `GarminDateRange` type and `garminDateRange` query
- **`src/datasources/OtelDataAPI.ts`** — Add `getGarminDateRange()` method with 60s cache TTL
- **`src/resolvers/garmin.ts`** — Add `garminDateRange` resolver
- **`src/__generated__/resolvers-types.ts`** — Regenerated TypeScript types
- **`packages/graphql-types/index.d.ts`** — Regenerated shared type definitions

## Context

This mirrors the existing `locationDateRange` query (#52) but for Garmin activity data. Depends on otel-data-api PR stuartshay/otel-data-api#84 for the REST endpoint.