### PR TITLE
fix: Add timeout to readiness probe backend check

### DIFF
--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -187,7 +187,10 @@ export class OtelDataAPI {
   }
 
   async getReady() {
-    return this.fetch<{ status: string; database?: string; version?: string }>({ path: '/ready' });
+    return this.fetch<{ status: string; database?: string; version?: string }>({
+      path: '/ready',
+      timeoutMs: 2_000,
+    });
   }
 
   // ── Locations ───────────────────────────────────────

--- a/tests/datasources/OtelDataAPI.test.ts
+++ b/tests/datasources/OtelDataAPI.test.ts
@@ -382,6 +382,34 @@ describe('OtelDataAPI', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('passes a 2s abort signal to fetch when calling getReady', async () => {
+    const timeoutSpy = jest.spyOn(AbortSignal, 'timeout');
+    const api = new OtelDataAPI('https://example.test');
+
+    await api.getReady();
+
+    expect(timeoutSpy).toHaveBeenCalledWith(2_000);
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(options.signal).toBeDefined();
+
+    timeoutSpy.mockRestore();
+  });
+
+  it('rejects when the ready endpoint times out', async () => {
+    fetchMock.mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          const signal = (init as RequestInit).signal!;
+          signal.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted', 'AbortError'));
+          });
+        }),
+    );
+    const api = new OtelDataAPI('https://example.test');
+
+    await expect(api.getReady()).rejects.toThrow('aborted');
+  });
+
   it('does not cache endpoints without cacheTtlMs', async () => {
     fetchMock.mockImplementation(() => jsonResponse({ status: 'healthy', version: '1.0.0' }));
     const api = new OtelDataAPI('https://example.test');


### PR DESCRIPTION
## Summary

The `/ready` REST endpoint calls `otel-data-api`'s `/ready` with the default 30s fetch timeout, but the K8s readiness probe has only a 3s timeout. When the backend or database is even slightly slow, the K8s probe times out before the gateway can respond, generating repeated `Unhealthy` warnings:

```
Readiness probe failed: Get "http://10.244.3.100:4000/ready": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

## Changes

- Add `timeoutMs: 2_000` to the `getReady()` fetch in `OtelDataAPI.ts` so the gateway aborts the backend call in 2 seconds and returns a proper 503 response before the K8s probe deadline.

## Companion PR

- stuartshay/k8s-gitops `fix/gateway-readiness-probe-timeout` — increases readiness probe `timeoutSeconds` from 3→5 for additional headroom.

## Testing

- `npm run type-check` ✅
- `npm run lint` ✅