### PR TITLE
feat(garmin): add garminActivityTotals query

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -29,7 +29,8 @@
     "postalcode",
     "shellcheck",
     "stuartshay",
-    "tini"
+    "tini",
+    "trunc"
   ],
   "ignorePaths": [
     "node_modules",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "lint-staged": {
     "*.ts": [
-      "eslint --fix --max-warnings 0",
+      "eslint --fix --max-warnings 0 --no-warn-ignored",
       "prettier --write"
     ],
     "*.{json,css}": [

--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -143,6 +143,23 @@ export interface GarminActivityConnection {
   total: Scalars['Int']['output'];
 }
 
+/** Aggregated Garmin activity totals for a single time bucket (week, month, or year). */
+export interface GarminActivityTotal {
+  __typename?: 'GarminActivityTotal';
+  /** Number of activities in the period */
+  activity_count: Scalars['Int']['output'];
+  /** Start date of the period bucket (DATE_TRUNC of week/month/year) */
+  period_start: Scalars['String']['output'];
+  /** Sum of elevation gain in meters */
+  total_ascent_m?: Maybe<Scalars['Int']['output']>;
+  /** Sum of calories burned */
+  total_calories?: Maybe<Scalars['Int']['output']>;
+  /** Sum of distance in kilometres */
+  total_distance_km?: Maybe<Scalars['Float']['output']>;
+  /** Sum of active duration in seconds (excludes pauses) */
+  total_duration_seconds?: Maybe<Scalars['Int']['output']>;
+}
+
 /** Lightweight track point optimised for time-series chart rendering. */
 export interface GarminChartPoint {
   __typename?: 'GarminChartPoint';
@@ -467,6 +484,8 @@ export interface Query {
   garminActivities: GarminActivityConnection;
   /** Retrieve a single Garmin activity by its ID. */
   garminActivity?: Maybe<GarminActivity>;
+  /** Aggregate Garmin activity totals grouped by week, month, or year. */
+  garminActivityTotals: Array<GarminActivityTotal>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
   garminChartData: Array<GarminChartPoint>;
   /** Get the earliest and latest Garmin activity timestamps. */
@@ -526,6 +545,13 @@ export interface QueryGarminActivitiesArgs {
 
 export interface QueryGarminActivityArgs {
   activity_id: Scalars['String']['input'];
+}
+
+export interface QueryGarminActivityTotalsArgs {
+  date_from?: InputMaybe<Scalars['String']['input']>;
+  date_to?: InputMaybe<Scalars['String']['input']>;
+  period: Scalars['String']['input'];
+  sport?: InputMaybe<Scalars['String']['input']>;
 }
 
 export interface QueryGarminChartDataArgs {

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -142,6 +142,23 @@ export type GarminActivityConnection = {
   total: Scalars['Int']['output'];
 };
 
+/** Aggregated Garmin activity totals for a single time bucket (week, month, or year). */
+export type GarminActivityTotal = {
+  __typename?: 'GarminActivityTotal';
+  /** Number of activities in the period */
+  activity_count: Scalars['Int']['output'];
+  /** Start date of the period bucket (DATE_TRUNC of week/month/year) */
+  period_start: Scalars['String']['output'];
+  /** Sum of elevation gain in meters */
+  total_ascent_m?: Maybe<Scalars['Int']['output']>;
+  /** Sum of calories burned */
+  total_calories?: Maybe<Scalars['Int']['output']>;
+  /** Sum of distance in kilometres */
+  total_distance_km?: Maybe<Scalars['Float']['output']>;
+  /** Sum of active duration in seconds (excludes pauses) */
+  total_duration_seconds?: Maybe<Scalars['Int']['output']>;
+};
+
 /** Lightweight track point optimised for time-series chart rendering. */
 export type GarminChartPoint = {
   __typename?: 'GarminChartPoint';
@@ -468,6 +485,8 @@ export type Query = {
   garminActivities: GarminActivityConnection;
   /** Retrieve a single Garmin activity by its ID. */
   garminActivity?: Maybe<GarminActivity>;
+  /** Aggregate Garmin activity totals grouped by week, month, or year. */
+  garminActivityTotals: Array<GarminActivityTotal>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
   garminChartData: Array<GarminChartPoint>;
   /** Get the earliest and latest Garmin activity timestamps. */
@@ -531,6 +550,14 @@ export type QueryGarminActivitiesArgs = {
 
 export type QueryGarminActivityArgs = {
   activity_id: Scalars['String']['input'];
+};
+
+
+export type QueryGarminActivityTotalsArgs = {
+  date_from?: InputMaybe<Scalars['String']['input']>;
+  date_to?: InputMaybe<Scalars['String']['input']>;
+  period: Scalars['String']['input'];
+  sport?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -785,6 +812,7 @@ export type ResolversTypes = ResolversObject<{
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   GarminActivity: ResolverTypeWrapper<GarminActivity>;
   GarminActivityConnection: ResolverTypeWrapper<GarminActivityConnection>;
+  GarminActivityTotal: ResolverTypeWrapper<GarminActivityTotal>;
   GarminChartPoint: ResolverTypeWrapper<GarminChartPoint>;
   GarminDateRange: ResolverTypeWrapper<GarminDateRange>;
   GarminSyncTriggerResult: ResolverTypeWrapper<GarminSyncTriggerResult>;
@@ -825,6 +853,7 @@ export type ResolversParentTypes = ResolversObject<{
   Float: Scalars['Float']['output'];
   GarminActivity: GarminActivity;
   GarminActivityConnection: GarminActivityConnection;
+  GarminActivityTotal: GarminActivityTotal;
   GarminChartPoint: GarminChartPoint;
   GarminDateRange: GarminDateRange;
   GarminSyncTriggerResult: GarminSyncTriggerResult;
@@ -920,6 +949,15 @@ export type GarminActivityConnectionResolvers<ContextType = GatewayContext, Pare
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   offset?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type GarminActivityTotalResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminActivityTotal'] = ResolversParentTypes['GarminActivityTotal']> = ResolversObject<{
+  activity_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  period_start?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  total_ascent_m?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  total_calories?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  total_distance_km?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  total_duration_seconds?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
 }>;
 
 export type GarminChartPointResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminChartPoint'] = ResolversParentTypes['GarminChartPoint']> = ResolversObject<{
@@ -1092,6 +1130,7 @@ export type QueryResolvers<ContextType = GatewayContext, ParentType extends Reso
   devices?: Resolver<Array<ResolversTypes['DeviceInfo']>, ParentType, ContextType>;
   garminActivities?: Resolver<ResolversTypes['GarminActivityConnection'], ParentType, ContextType, Partial<QueryGarminActivitiesArgs>>;
   garminActivity?: Resolver<Maybe<ResolversTypes['GarminActivity']>, ParentType, ContextType, RequireFields<QueryGarminActivityArgs, 'activity_id'>>;
+  garminActivityTotals?: Resolver<Array<ResolversTypes['GarminActivityTotal']>, ParentType, ContextType, RequireFields<QueryGarminActivityTotalsArgs, 'period'>>;
   garminChartData?: Resolver<Array<ResolversTypes['GarminChartPoint']>, ParentType, ContextType, RequireFields<QueryGarminChartDataArgs, 'activity_id'>>;
   garminDateRange?: Resolver<ResolversTypes['GarminDateRange'], ParentType, ContextType>;
   garminSports?: Resolver<Array<ResolversTypes['SportInfo']>, ParentType, ContextType>;
@@ -1166,6 +1205,7 @@ export type Resolvers<ContextType = GatewayContext> = ResolversObject<{
   DistanceResult?: DistanceResultResolvers<ContextType>;
   GarminActivity?: GarminActivityResolvers<ContextType>;
   GarminActivityConnection?: GarminActivityConnectionResolvers<ContextType>;
+  GarminActivityTotal?: GarminActivityTotalResolvers<ContextType>;
   GarminChartPoint?: GarminChartPointResolvers<ContextType>;
   GarminDateRange?: GarminDateRangeResolvers<ContextType>;
   GarminSyncTriggerResult?: GarminSyncTriggerResultResolvers<ContextType>;

--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -302,6 +302,30 @@ export class OtelDataAPI {
     });
   }
 
+  async getGarminActivityTotals(
+    params: Nullable<{
+      period: string;
+      sport?: string;
+      date_from?: string;
+      date_to?: string;
+    }>,
+  ) {
+    return this.fetch<
+      {
+        period_start: string;
+        activity_count: number;
+        total_distance_km: number | null;
+        total_duration_seconds: number | null;
+        total_ascent_m: number | null;
+        total_calories: number | null;
+      }[]
+    >({
+      path: '/api/v1/garmin/activity-totals',
+      query: params,
+      cacheTtlMs: 30_000,
+    });
+  }
+
   async triggerGarminSync(
     params?: Nullable<{
       window_hours?: number;

--- a/src/resolvers/garmin.ts
+++ b/src/resolvers/garmin.ts
@@ -9,6 +9,7 @@ export const garminResolvers: {
     | 'garminTrackPoints'
     | 'garminSports'
     | 'garminChartData'
+    | 'garminActivityTotals'
   >;
   Mutation: Pick<MutationResolvers, 'triggerGarminSync'>;
 } = {
@@ -36,6 +37,10 @@ export const garminResolvers: {
 
     garminChartData: async (_parent, args, { dataSources }) => {
       return dataSources.otelAPI.getGarminChartData(args.activity_id);
+    },
+
+    garminActivityTotals: async (_parent, args, { dataSources }) => {
+      return dataSources.otelAPI.getGarminActivityTotals(args);
     },
   },
   Mutation: {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -654,6 +654,36 @@ type GarminChartPoint {
   longitude: Float!
 }
 
+"""
+Aggregated Garmin activity totals for a single time bucket (week, month, or year).
+"""
+type GarminActivityTotal {
+  """
+  Start date of the period bucket (DATE_TRUNC of week/month/year)
+  """
+  period_start: String!
+  """
+  Number of activities in the period
+  """
+  activity_count: Int!
+  """
+  Sum of distance in kilometres
+  """
+  total_distance_km: Float
+  """
+  Sum of active duration in seconds (excludes pauses)
+  """
+  total_duration_seconds: Int
+  """
+  Sum of elevation gain in meters
+  """
+  total_ascent_m: Int
+  """
+  Sum of calories burned
+  """
+  total_calories: Int
+}
+
 # -------------------------------------------------------
 # Unified GPS
 # -------------------------------------------------------
@@ -1133,6 +1163,28 @@ type Query {
     """
     activity_id: String!
   ): [GarminChartPoint!]!
+
+  """
+  Aggregate Garmin activity totals grouped by week, month, or year.
+  """
+  garminActivityTotals(
+    """
+    Aggregation period: 'week', 'month', or 'year'
+    """
+    period: String!
+    """
+    Filter by sport (e.g. cycling, running)
+    """
+    sport: String
+    """
+    Inclusive lower bound on activity start time (YYYY-MM-DD)
+    """
+    date_from: String
+    """
+    Inclusive upper bound on activity start time (YYYY-MM-DD)
+    """
+    date_to: String
+  ): [GarminActivityTotal!]!
 
   # Unified GPS
   """

--- a/tests/datasources/OtelDataAPI.test.ts
+++ b/tests/datasources/OtelDataAPI.test.ts
@@ -473,6 +473,23 @@ describe('OtelDataAPI', () => {
     nowSpy.mockRestore();
   });
 
+  it('caches garminActivityTotals responses for 30s', async () => {
+    fetchMock.mockImplementation(() => jsonResponse([]));
+    const api = new OtelDataAPI('https://example.test');
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    nowSpy.mockReturnValue(0);
+    await api.getGarminActivityTotals({ period: 'week' });
+    await api.getGarminActivityTotals({ period: 'week' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    nowSpy.mockReturnValue(31_000);
+    await api.getGarminActivityTotals({ period: 'week' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    nowSpy.mockRestore();
+  });
+
   it('caches garminDateRange responses for 60s', async () => {
     fetchMock.mockImplementation(() =>
       jsonResponse({ min_date: '2020-01-01T00:00:00Z', max_date: '2026-04-01T00:00:00Z' }),

--- a/tests/datasources/OtelDataAPI.test.ts
+++ b/tests/datasources/OtelDataAPI.test.ts
@@ -319,6 +319,7 @@ describe('OtelDataAPI', () => {
     await api.getGarminTrackPoints('ga-1', { limit: 2 });
     await api.getGarminSports();
     await api.getGarminChartData('ga-1');
+    await api.getGarminActivityTotals({ period: 'week' });
     await api.triggerGarminSync({ window_hours: 24 });
     await api.getUnifiedGps({ source: 'gps' });
     await api.getDailySummary({ limit: 3 });
@@ -345,6 +346,7 @@ describe('OtelDataAPI', () => {
       '/api/v1/garmin/activities/ga-1/tracks',
       '/api/v1/garmin/sports',
       '/api/v1/garmin/activities/ga-1/chart-data',
+      '/api/v1/garmin/activity-totals',
       '/api/v1/garmin/sync',
       '/api/v1/gps/unified',
       '/api/v1/gps/daily-summary',

--- a/tests/resolvers/resolvers.test.ts
+++ b/tests/resolvers/resolvers.test.ts
@@ -175,6 +175,20 @@ describe('garmin resolvers', () => {
     expect(ctx.dataSources.otelAPI.getGarminChartData).toHaveBeenCalledWith('abc');
   });
 
+  it('passes filter args to garminActivityTotals', async () => {
+    const args = {
+      period: 'week',
+      sport: 'cycling',
+      date_from: '2025-01-01',
+      date_to: '2025-12-31',
+    };
+    const ctx = contextWith({ getGarminActivityTotals: mockAsync([]) });
+
+    await runResolver(garminResolvers.Query.garminActivityTotals, args, ctx);
+
+    expect(ctx.dataSources.otelAPI.getGarminActivityTotals).toHaveBeenCalledWith(args);
+  });
+
   it('delegates garminDateRange to datasource', async () => {
     const result = { min_date: '2020-01-01T00:00:00Z', max_date: '2026-04-01T00:00:00Z' };
     const ctx = contextWith({ getGarminDateRange: mockAsync(result) });


### PR DESCRIPTION
## Summary

Adds the `garminActivityTotals` GraphQL query, proxying `GET /api/v1/garmin/activity-totals` from `otel-data-api` (added in stuartshay/otel-data-api#97). This unblocks the planned dashboard widget in `otel-data-ui` that displays weekly / monthly / yearly Garmin activity aggregates (count, distance, duration, ascent, calories).

Refs #66
Upstream API: stuartshay/otel-data-api#97 / stuartshay/otel-data-api#96

## Changes

- **Schema** (`src/schema/schema.graphql`): new `GarminActivityTotal` type and `garminActivityTotals(period, sport, date_from, date_to)` query. `period_start` is typed as `String!` because the upstream API returns plain `YYYY-MM-DD`.
- **Datasource** (`src/datasources/OtelDataAPI.ts`): `getGarminActivityTotals(...)` with 30s cache TTL, matching the cache strategy used for other Garmin endpoints.
- **Resolver** (`src/resolvers/garmin.ts`): pure delegation to the datasource.
- **Codegen**: regenerated `src/__generated__/resolvers-types.ts` and `packages/graphql-types/index.d.ts` (the published `@stuartshay/otel-graphql-types`).
- **Tests**: resolver delegation test + datasource route registration test.
- **cspell**: allow `TRUNC` (used in upstream schema doc comment).
- **lint-staged**: `--no-warn-ignored` so generated TS files don't fail the pre-commit hook.

## Validation

- `npm run lint:all` ✅
- `npm run type-check` ✅
- `npm run build` ✅
- `npm test` ✅ (50 passed, coverage 93%+)

## Follow-up

After merge, the `publish-types.yml` workflow will release a new `@stuartshay/otel-graphql-types` version, which will open an auto-PR in `otel-data-ui`. The UI widget will be implemented in a follow-up PR once the types bump lands.
