### PR TITLE
feat(daily-summary): add pagination and date-range query

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -3,17 +3,21 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = {
+  [_ in K]?: never;
+};
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export interface Scalars {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
-  DateTime: { input: string; output: string; }
-  JSON: { input: Record<string, unknown>; output: Record<string, unknown>; }
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  DateTime: { input: string; output: string };
+  JSON: { input: Record<string, unknown>; output: Record<string, unknown> };
 }
 
 /** Per-day aggregate combining OwnTracks location stats and Garmin activity metrics. */
@@ -452,12 +456,10 @@ export interface Mutation {
   triggerGeocoding: GeocodingTriggerResult;
 }
 
-
 export interface MutationTriggerGarminSyncArgs {
   lookback?: InputMaybe<Scalars['Int']['input']>;
   window_hours?: InputMaybe<Scalars['Int']['input']>;
 }
-
 
 export interface MutationTriggerGeocodingArgs {
   batch_size?: InputMaybe<Scalars['Int']['input']>;
@@ -542,7 +544,6 @@ export interface Query {
   withinReference: WithinReferenceResult;
 }
 
-
 export interface QueryCalculateDistanceArgs {
   from_lat: Scalars['Float']['input'];
   from_lon: Scalars['Float']['input'];
@@ -550,14 +551,12 @@ export interface QueryCalculateDistanceArgs {
   to_lon: Scalars['Float']['input'];
 }
 
-
 export interface QueryDailySummaryArgs {
   date_from?: InputMaybe<Scalars['String']['input']>;
   date_to?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
 }
-
 
 export interface QueryGarminActivitiesArgs {
   date_from?: InputMaybe<Scalars['String']['input']>;
@@ -568,7 +567,6 @@ export interface QueryGarminActivitiesArgs {
   sort?: InputMaybe<Scalars['String']['input']>;
   sport?: InputMaybe<Scalars['String']['input']>;
 }
-
 
 export interface QueryGarminActivityArgs {
   activity_id: Scalars['String']['input'];
@@ -585,7 +583,6 @@ export interface QueryGarminChartDataArgs {
   activity_id: Scalars['String']['input'];
 }
 
-
 export interface QueryGarminTrackPointsArgs {
   activity_id: Scalars['String']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -595,17 +592,14 @@ export interface QueryGarminTrackPointsArgs {
   sort?: InputMaybe<Scalars['String']['input']>;
 }
 
-
 export interface QueryLocationArgs {
   id: Scalars['Int']['input'];
 }
-
 
 export interface QueryLocationCountArgs {
   date?: InputMaybe<Scalars['String']['input']>;
   device_id?: InputMaybe<Scalars['String']['input']>;
 }
-
 
 export interface QueryLocationsArgs {
   date_from?: InputMaybe<Scalars['String']['input']>;
@@ -617,7 +611,6 @@ export interface QueryLocationsArgs {
   sort?: InputMaybe<Scalars['String']['input']>;
 }
 
-
 export interface QueryNearbyPointsArgs {
   lat: Scalars['Float']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -626,11 +619,9 @@ export interface QueryNearbyPointsArgs {
   source?: InputMaybe<Scalars['String']['input']>;
 }
 
-
 export interface QueryReferenceLocationArgs {
   id: Scalars['Int']['input'];
 }
-
 
 export interface QueryUnifiedGpsArgs {
   date_from?: InputMaybe<Scalars['String']['input']>;
@@ -642,7 +633,6 @@ export interface QueryUnifiedGpsArgs {
   order?: InputMaybe<SortOrder>;
   source?: InputMaybe<Scalars['String']['input']>;
 }
-
 
 export interface QueryWithinReferenceArgs {
   limit?: InputMaybe<Scalars['Int']['input']>;

--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -3,21 +3,17 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = {
-  [_ in K]?: never;
-};
-export type Incremental<T> =
-  | T
-  | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export interface Scalars {
-  ID: { input: string; output: string };
-  String: { input: string; output: string };
-  Boolean: { input: boolean; output: boolean };
-  Int: { input: number; output: number };
-  Float: { input: number; output: number };
-  DateTime: { input: string; output: string };
-  JSON: { input: Record<string, unknown>; output: Record<string, unknown> };
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  DateTime: { input: string; output: string; }
+  JSON: { input: Record<string, unknown>; output: Record<string, unknown>; }
 }
 
 /** Per-day aggregate combining OwnTracks location stats and Garmin activity metrics. */
@@ -47,6 +43,28 @@ export interface DailyActivitySummary {
   total_distance_km?: Maybe<Scalars['Float']['output']>;
   /** Combined Garmin activity duration in seconds */
   total_duration_seconds?: Maybe<Scalars['Float']['output']>;
+}
+
+/** Paginated list of daily activity summaries. */
+export interface DailySummaryConnection {
+  __typename?: 'DailySummaryConnection';
+  /** List of daily activity summary items in the current page */
+  items: Array<DailyActivitySummary>;
+  /** Maximum number of items per page */
+  limit: Scalars['Int']['output'];
+  /** Number of items skipped from the start */
+  offset: Scalars['Int']['output'];
+  /** Total number of items matching the query */
+  total: Scalars['Int']['output'];
+}
+
+/** Earliest and latest activity dates available in the daily activity summary view. */
+export interface DailySummaryDateRange {
+  __typename?: 'DailySummaryDateRange';
+  /** Latest activity date with daily summary data (YYYY-MM-DD) */
+  max_date: Scalars['String']['output'];
+  /** Earliest activity date with daily summary data (YYYY-MM-DD) */
+  min_date: Scalars['String']['output'];
 }
 
 /** Distinct OwnTracks device identifier. */
@@ -434,10 +452,12 @@ export interface Mutation {
   triggerGeocoding: GeocodingTriggerResult;
 }
 
+
 export interface MutationTriggerGarminSyncArgs {
   lookback?: InputMaybe<Scalars['Int']['input']>;
   window_hours?: InputMaybe<Scalars['Int']['input']>;
 }
+
 
 export interface MutationTriggerGeocodingArgs {
   batch_size?: InputMaybe<Scalars['Int']['input']>;
@@ -477,7 +497,9 @@ export interface Query {
   /** Calculate the geodesic distance between two geographic points. */
   calculateDistance: DistanceResult;
   /** Retrieve daily activity summaries combining OwnTracks and Garmin data. */
-  dailySummary: Array<DailyActivitySummary>;
+  dailySummary: DailySummaryConnection;
+  /** Get the earliest and latest activity dates available in the daily activity summary view. */
+  dailySummaryDateRange: DailySummaryDateRange;
   /** List all distinct OwnTracks device identifiers. */
   devices: Array<DeviceInfo>;
   /** Retrieve a paginated list of Garmin activities. */
@@ -520,6 +542,7 @@ export interface Query {
   withinReference: WithinReferenceResult;
 }
 
+
 export interface QueryCalculateDistanceArgs {
   from_lat: Scalars['Float']['input'];
   from_lon: Scalars['Float']['input'];
@@ -527,11 +550,14 @@ export interface QueryCalculateDistanceArgs {
   to_lon: Scalars['Float']['input'];
 }
 
+
 export interface QueryDailySummaryArgs {
   date_from?: InputMaybe<Scalars['String']['input']>;
   date_to?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }
+
 
 export interface QueryGarminActivitiesArgs {
   date_from?: InputMaybe<Scalars['String']['input']>;
@@ -542,6 +568,7 @@ export interface QueryGarminActivitiesArgs {
   sort?: InputMaybe<Scalars['String']['input']>;
   sport?: InputMaybe<Scalars['String']['input']>;
 }
+
 
 export interface QueryGarminActivityArgs {
   activity_id: Scalars['String']['input'];
@@ -558,6 +585,7 @@ export interface QueryGarminChartDataArgs {
   activity_id: Scalars['String']['input'];
 }
 
+
 export interface QueryGarminTrackPointsArgs {
   activity_id: Scalars['String']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -567,14 +595,17 @@ export interface QueryGarminTrackPointsArgs {
   sort?: InputMaybe<Scalars['String']['input']>;
 }
 
+
 export interface QueryLocationArgs {
   id: Scalars['Int']['input'];
 }
+
 
 export interface QueryLocationCountArgs {
   date?: InputMaybe<Scalars['String']['input']>;
   device_id?: InputMaybe<Scalars['String']['input']>;
 }
+
 
 export interface QueryLocationsArgs {
   date_from?: InputMaybe<Scalars['String']['input']>;
@@ -586,6 +617,7 @@ export interface QueryLocationsArgs {
   sort?: InputMaybe<Scalars['String']['input']>;
 }
 
+
 export interface QueryNearbyPointsArgs {
   lat: Scalars['Float']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -594,9 +626,11 @@ export interface QueryNearbyPointsArgs {
   source?: InputMaybe<Scalars['String']['input']>;
 }
 
+
 export interface QueryReferenceLocationArgs {
   id: Scalars['Int']['input'];
 }
+
 
 export interface QueryUnifiedGpsArgs {
   date_from?: InputMaybe<Scalars['String']['input']>;
@@ -608,6 +642,7 @@ export interface QueryUnifiedGpsArgs {
   order?: InputMaybe<SortOrder>;
   source?: InputMaybe<Scalars['String']['input']>;
 }
+
 
 export interface QueryWithinReferenceArgs {
   limit?: InputMaybe<Scalars['Int']['input']>;

--- a/packages/graphql-types/schema.graphql
+++ b/packages/graphql-types/schema.graphql
@@ -6,234 +6,1019 @@ scalar DateTime
 # -------------------------------------------------------
 # Common Types
 # -------------------------------------------------------
+"""
+Pagination metadata for paginated list responses.
+"""
 type PaginationInfo {
+  """
+  Total number of items matching the query
+  """
   total: Int!
+  """
+  Maximum number of items per page
+  """
   limit: Int!
+  """
+  Number of items skipped from the start
+  """
   offset: Int!
 }
 
 # -------------------------------------------------------
 # Health
 # -------------------------------------------------------
+"""
+Service health status.
+"""
 type HealthStatus {
+  """
+  Service health status (healthy or unhealthy)
+  """
   status: String!
+  """
+  Application version from VERSION file
+  """
   version: String!
 }
 
+"""
+Service readiness status including database connectivity.
+"""
 type ReadyStatus {
+  """
+  Service readiness status
+  """
   status: String!
+  """
+  Database connection status
+  """
   database: String
+  """
+  Application version from VERSION file
+  """
   version: String
 }
 
 # -------------------------------------------------------
 # Locations (OwnTracks)
 # -------------------------------------------------------
+"""
+GPS location recorded by the OwnTracks mobile app.
+"""
 type Location {
+  """
+  Unique location record identifier
+  """
   id: Int!
+  """
+  OwnTracks device identifier (e.g. iphone_stuart)
+  """
   device_id: String!
+  """
+  Two-character tracker ID set in the OwnTracks app
+  """
   tid: String
+  """
+  GPS latitude in decimal degrees (WGS 84)
+  """
   latitude: Float!
+  """
+  GPS longitude in decimal degrees (WGS 84)
+  """
   longitude: Float!
+  """
+  Horizontal accuracy of the GPS fix in meters
+  """
   accuracy: Float
+  """
+  Altitude above sea level in meters
+  """
   altitude: Float
+  """
+  Device velocity in km/h at time of report
+  """
   velocity: Float
+  """
+  Device battery level as a percentage (0-100)
+  """
   battery: Int
+  """
+  Battery charging state (0=unknown, 1=unplugged, 2=charging, 3=full)
+  """
   battery_status: Int
+  """
+  Network connection type (w=WiFi, m=mobile)
+  """
   connection_type: String
+  """
+  What triggered this location report (p=ping, c=circular, t=timer)
+  """
   trigger: String
+  """
+  UTC timestamp when the device recorded the location
+  """
   timestamp: DateTime!
+  """
+  UTC timestamp when the record was inserted into the database
+  """
   created_at: String
+  """
+  Short formatted address from reverse geocoding
+  """
+  display_address: String
 }
 
+"""
+Full location detail including the original OwnTracks JSON payload.
+"""
 type LocationDetail {
+  """
+  Unique location record identifier
+  """
   id: Int!
+  """
+  OwnTracks device identifier (e.g. iphone_stuart)
+  """
   device_id: String!
+  """
+  Two-character tracker ID set in the OwnTracks app
+  """
   tid: String
+  """
+  GPS latitude in decimal degrees (WGS 84)
+  """
   latitude: Float!
+  """
+  GPS longitude in decimal degrees (WGS 84)
+  """
   longitude: Float!
+  """
+  Horizontal accuracy of the GPS fix in meters
+  """
   accuracy: Float
+  """
+  Altitude above sea level in meters
+  """
   altitude: Float
+  """
+  Device velocity in km/h at time of report
+  """
   velocity: Float
+  """
+  Device battery level as a percentage (0-100)
+  """
   battery: Int
+  """
+  Battery charging state (0=unknown, 1=unplugged, 2=charging, 3=full)
+  """
   battery_status: Int
+  """
+  Network connection type (w=WiFi, m=mobile)
+  """
   connection_type: String
+  """
+  What triggered this location report (p=ping, c=circular, t=timer)
+  """
   trigger: String
+  """
+  UTC timestamp when the device recorded the location
+  """
   timestamp: DateTime!
+  """
+  UTC timestamp when the record was inserted into the database
+  """
   created_at: String
+  """
+  Original OwnTracks JSON payload as received from the MQTT broker
+  """
   raw_payload: JSON
+  """
+  Full reverse-geocoded address components from Pelias
+  """
+  address: GeocodedAddress
 }
 
 scalar JSON
 
+# -------------------------------------------------------
+# Geocoding
+# -------------------------------------------------------
+"""
+Reverse-geocoded address components from Pelias.
+"""
+type GeocodedAddress {
+  """
+  Full formatted address label from Pelias
+  """
+  display_address: String
+  """
+  Street name
+  """
+  street: String
+  """
+  House or building number
+  """
+  housenumber: String
+  """
+  Neighbourhood name
+  """
+  neighbourhood: String
+  """
+  City or town
+  """
+  locality: String
+  """
+  State or province
+  """
+  region: String
+  """
+  Country name
+  """
+  country: String
+  """
+  Postal or ZIP code
+  """
+  postalcode: String
+  """
+  Pelias confidence score (0-1)
+  """
+  confidence: Float
+  """
+  Geocoding status: success, no_coverage, error, pending
+  """
+  status: String!
+  """
+  UTC timestamp when geocoding was performed
+  """
+  geocoded_at: String
+}
+
+"""
+Coverage statistics for geocoded location records.
+"""
+type GeocodingStatus {
+  """
+  Total number of OwnTracks location records
+  """
+  total_locations: Int!
+  """
+  Number of locations with a geocoded address (any status)
+  """
+  geocoded: Int!
+  """
+  Number of successfully geocoded locations
+  """
+  success: Int!
+  """
+  Number of locations awaiting geocoding
+  """
+  pending: Int!
+  """
+  Number of locations outside Pelias coverage area
+  """
+  no_coverage: Int!
+  """
+  Number of locations that failed geocoding
+  """
+  errors: Int!
+  """
+  Percentage of locations with a geocoded address
+  """
+  coverage_percent: Float!
+}
+
+"""
+Result of triggering a batch geocoding operation.
+"""
+type GeocodingTriggerResult {
+  """
+  Number of records processed in this batch
+  """
+  processed: Int!
+  """
+  Number of records still awaiting geocoding
+  """
+  remaining: Int!
+  """
+  Number of records skipped via proximity deduplication
+  """
+  skipped_dedup: Int!
+}
+
+"""
+Paginated list of OwnTracks location records.
+"""
 type LocationConnection {
+  """
+  List of location items in the current page
+  """
   items: [Location!]!
+  """
+  Total number of items matching the query
+  """
   total: Int!
+  """
+  Maximum number of items per page
+  """
   limit: Int!
+  """
+  Number of items skipped from the start
+  """
   offset: Int!
 }
 
+"""
+Distinct OwnTracks device identifier.
+"""
 type DeviceInfo {
+  """
+  OwnTracks device identifier
+  """
   device_id: String!
 }
 
+"""
+Aggregate location count with optional filter context.
+"""
 type LocationCount {
+  """
+  Total number of location records matching the filter
+  """
   count: Int!
+  """
+  Date filter applied (YYYY-MM-DD), if any
+  """
   date: String
+  """
+  Device ID filter applied, if any
+  """
   device_id: String
+}
+
+"""
+Earliest and latest timestamps in the locations table.
+"""
+type LocationDateRange {
+  """
+  Earliest location timestamp (ISO 8601)
+  """
+  min_date: DateTime!
+  """
+  Latest location timestamp (ISO 8601)
+  """
+  max_date: DateTime!
 }
 
 # -------------------------------------------------------
 # Garmin
 # -------------------------------------------------------
+"""
+Summary of a Garmin Connect activity parsed from a FIT file.
+"""
 type GarminActivity {
+  """
+  Garmin Connect activity identifier
+  """
   activity_id: String!
+  """
+  Primary sport type (e.g. cycling, running)
+  """
   sport: String!
+  """
+  Sub-sport classification (e.g. road, trail)
+  """
   sub_sport: String
+  """
+  Activity start time in UTC
+  """
   start_time: String
+  """
+  Activity end time in UTC
+  """
   end_time: String
+  """
+  Total distance in kilometres
+  """
   distance_km: Float
+  """
+  Active duration in seconds (excludes pauses)
+  """
   duration_seconds: Float
+  """
+  Average heart rate in beats per minute
+  """
   avg_heart_rate: Int
+  """
+  Maximum heart rate in beats per minute
+  """
   max_heart_rate: Int
+  """
+  Average cadence in RPM
+  """
   avg_cadence: Int
+  """
+  Maximum cadence in RPM
+  """
   max_cadence: Int
+  """
+  Total calories burned
+  """
   calories: Int
+  """
+  Average speed in km/h
+  """
   avg_speed_kmh: Float
+  """
+  Maximum speed in km/h
+  """
   max_speed_kmh: Float
+  """
+  Total elevation gain in meters
+  """
   total_ascent_m: Float
+  """
+  Total elevation loss in meters
+  """
   total_descent_m: Float
+  """
+  Raw total distance in meters from FIT file
+  """
   total_distance: Float
+  """
+  Average pace in minutes per kilometre
+  """
   avg_pace: Float
+  """
+  Device manufacturer (e.g. garmin)
+  """
   device_manufacturer: String
+  """
+  Average ambient temperature in degrees C
+  """
   avg_temperature_c: Int
+  """
+  Minimum ambient temperature in degrees C
+  """
   min_temperature_c: Int
+  """
+  Maximum ambient temperature in degrees C
+  """
   max_temperature_c: Int
+  """
+  Total elapsed time in seconds (includes pauses)
+  """
   total_elapsed_time: Float
+  """
+  Total timer time in seconds (active recording)
+  """
   total_timer_time: Float
+  """
+  UTC timestamp when the record was inserted
+  """
   created_at: String
+  """
+  UTC timestamp when the FIT file was uploaded
+  """
   uploaded_at: String
+  """
+  Number of GPS track points in this activity
+  """
   track_point_count: Int
 }
 
+"""
+Paginated list of Garmin activities.
+"""
 type GarminActivityConnection {
+  """
+  List of Garmin activity items in the current page
+  """
   items: [GarminActivity!]!
+  """
+  Total number of items matching the query
+  """
   total: Int!
+  """
+  Maximum number of items per page
+  """
   limit: Int!
+  """
+  Number of items skipped from the start
+  """
   offset: Int!
 }
 
+"""
+Earliest and latest timestamps in the Garmin activities table.
+"""
+type GarminDateRange {
+  """
+  Earliest Garmin activity timestamp (ISO 8601)
+  """
+  min_date: DateTime!
+  """
+  Latest Garmin activity timestamp (ISO 8601)
+  """
+  max_date: DateTime!
+}
+
+"""
+Individual GPS track point within a Garmin activity.
+"""
 type GarminTrackPoint {
+  """
+  Unique track point record identifier
+  """
   id: Int!
+  """
+  Parent Garmin activity identifier
+  """
   activity_id: String!
+  """
+  GPS latitude in decimal degrees (WGS 84)
+  """
   latitude: Float!
+  """
+  GPS longitude in decimal degrees (WGS 84)
+  """
   longitude: Float!
+  """
+  UTC timestamp of the track point recording
+  """
   timestamp: DateTime!
+  """
+  Elevation above sea level in meters
+  """
   altitude: Float
+  """
+  Cumulative distance from activity start in km
+  """
   distance_from_start_km: Float
+  """
+  Instantaneous speed in km/h
+  """
   speed_kmh: Float
+  """
+  Heart rate in beats per minute
+  """
   heart_rate: Int
+  """
+  Pedal/step cadence in RPM
+  """
   cadence: Int
+  """
+  Ambient temperature in degrees C
+  """
   temperature_c: Float
+  """
+  UTC timestamp when the record was inserted
+  """
   created_at: String
 }
 
+"""
+Paginated list of Garmin track points.
+"""
 type GarminTrackPointConnection {
+  """
+  List of track point items in the current page
+  """
   items: [GarminTrackPoint!]!
+  """
+  Total number of items matching the query
+  """
   total: Int!
+  """
+  Maximum number of items per page
+  """
   limit: Int!
+  """
+  Number of items skipped from the start
+  """
   offset: Int!
 }
 
+"""
+Sport type with its activity count.
+"""
 type SportInfo {
+  """
+  Sport type name (e.g. cycling, running)
+  """
   sport: String!
+  """
+  Number of activities for this sport
+  """
   activity_count: Int!
+}
+
+"""
+Lightweight track point optimised for time-series chart rendering.
+"""
+type GarminChartPoint {
+  """
+  UTC timestamp of the data point
+  """
+  timestamp: DateTime!
+  """
+  Elevation above sea level in meters
+  """
+  altitude: Float
+  """
+  Cumulative distance from activity start in km
+  """
+  distance_from_start_km: Float
+  """
+  Instantaneous speed in km/h
+  """
+  speed_kmh: Float
+  """
+  Heart rate in beats per minute
+  """
+  heart_rate: Int
+  """
+  Pedal/step cadence in RPM
+  """
+  cadence: Int
+  """
+  Ambient temperature in degrees C
+  """
+  temperature_c: Float
+  """
+  GPS latitude in decimal degrees (WGS 84)
+  """
+  latitude: Float!
+  """
+  GPS longitude in decimal degrees (WGS 84)
+  """
+  longitude: Float!
+}
+
+"""
+Aggregated Garmin activity totals for a single time bucket (week, month, or year).
+"""
+type GarminActivityTotal {
+  """
+  Start date of the period bucket (DATE_TRUNC of week/month/year)
+  """
+  period_start: String!
+  """
+  Number of activities in the period
+  """
+  activity_count: Int!
+  """
+  Sum of distance in kilometres
+  """
+  total_distance_km: Float
+  """
+  Sum of active duration in seconds (excludes pauses)
+  """
+  total_duration_seconds: Int
+  """
+  Sum of elevation gain in meters
+  """
+  total_ascent_m: Int
+  """
+  Sum of calories burned
+  """
+  total_calories: Int
 }
 
 # -------------------------------------------------------
 # Unified GPS
 # -------------------------------------------------------
+"""
+Single GPS data point from the unified view combining OwnTracks and Garmin sources.
+"""
 type UnifiedGpsPoint {
+  """
+  Data source: 'owntracks' or 'garmin'
+  """
   source: String!
+  """
+  Device or activity identifier from the source
+  """
   identifier: String!
+  """
+  GPS latitude in decimal degrees (WGS 84)
+  """
   latitude: Float!
+  """
+  GPS longitude in decimal degrees (WGS 84)
+  """
   longitude: Float!
+  """
+  UTC timestamp of the GPS recording
+  """
   timestamp: DateTime!
+  """
+  Horizontal GPS accuracy in meters (OwnTracks only)
+  """
   accuracy: Float
+  """
+  Device battery percentage (OwnTracks only)
+  """
   battery: Int
+  """
+  Instantaneous speed in km/h (Garmin only)
+  """
   speed_kmh: Float
+  """
+  Heart rate in BPM (Garmin only)
+  """
   heart_rate: Int
+  """
+  UTC timestamp when the record was inserted
+  """
   created_at: String
 }
 
+"""
+Paginated list of unified GPS data points.
+"""
 type UnifiedGpsConnection {
+  """
+  List of unified GPS items in the current page
+  """
   items: [UnifiedGpsPoint!]!
+  """
+  Total number of items matching the query
+  """
   total: Int!
+  """
+  Maximum number of items per page
+  """
   limit: Int!
+  """
+  Number of items skipped from the start
+  """
   offset: Int!
 }
 
+"""
+Per-day aggregate combining OwnTracks location stats and Garmin activity metrics.
+"""
 type DailyActivitySummary {
+  """
+  Calendar date in YYYY-MM-DD format
+  """
   activity_date: String
+  """
+  OwnTracks device that reported data for this day
+  """
   owntracks_device: String
+  """
+  Number of OwnTracks GPS points recorded
+  """
   owntracks_points: Int
+  """
+  Lowest device battery percentage observed
+  """
   min_battery: Int
+  """
+  Highest device battery percentage observed
+  """
   max_battery: Int
+  """
+  Mean horizontal GPS accuracy in meters
+  """
   avg_accuracy: Float
+  """
+  Garmin sport type for activities on this day
+  """
   garmin_sport: String
+  """
+  Number of Garmin activities recorded
+  """
   garmin_activities: Int
+  """
+  Combined Garmin activity distance in km
+  """
   total_distance_km: Float
+  """
+  Combined Garmin activity duration in seconds
+  """
   total_duration_seconds: Float
+  """
+  Mean heart rate across Garmin activities in BPM
+  """
   avg_heart_rate: Int
+  """
+  Total calories burned across Garmin activities
+  """
   total_calories: Int
+}
+
+"""
+Paginated list of daily activity summaries.
+"""
+type DailySummaryConnection {
+  """
+  List of daily activity summary items in the current page
+  """
+  items: [DailyActivitySummary!]!
+  """
+  Total number of items matching the query
+  """
+  total: Int!
+  """
+  Maximum number of items per page
+  """
+  limit: Int!
+  """
+  Number of items skipped from the start
+  """
+  offset: Int!
+}
+
+"""
+Earliest and latest activity dates available in the daily activity summary view.
+"""
+type DailySummaryDateRange {
+  """
+  Earliest activity date with daily summary data (YYYY-MM-DD)
+  """
+  min_date: String!
+  """
+  Latest activity date with daily summary data (YYYY-MM-DD)
+  """
+  max_date: String!
 }
 
 # -------------------------------------------------------
 # Reference Locations
 # -------------------------------------------------------
+"""
+Named geographic reference point used for spatial queries (e.g. home, office).
+"""
 type ReferenceLocation {
+  """
+  Unique reference location identifier
+  """
   id: Int!
+  """
+  Short, unique name for the location (e.g. home, office)
+  """
   name: String!
+  """
+  GPS latitude in decimal degrees (WGS 84)
+  """
   latitude: Float!
+  """
+  GPS longitude in decimal degrees (WGS 84)
+  """
   longitude: Float!
+  """
+  Geofence radius in meters for proximity queries
+  """
   radius_meters: Float!
+  """
+  Optional human-readable description of the location
+  """
   description: String
+  """
+  UTC timestamp when the record was created
+  """
   created_at: String
+  """
+  UTC timestamp when the record was last updated
+  """
   updated_at: String
 }
 
 # -------------------------------------------------------
 # Spatial
 # -------------------------------------------------------
+"""
+GPS point found within a spatial proximity search.
+"""
 type NearbyPoint {
+  """
+  Data source: 'owntracks' or 'garmin'
+  """
   source: String!
+  """
+  Record identifier in the source table
+  """
   id: Int!
+  """
+  GPS latitude in decimal degrees (WGS 84)
+  """
   latitude: Float!
+  """
+  GPS longitude in decimal degrees (WGS 84)
+  """
   longitude: Float!
+  """
+  Distance from the search center point in meters
+  """
   distance_meters: Float!
+  """
+  UTC timestamp of the GPS recording
+  """
   timestamp: DateTime!
 }
 
+"""
+Geodesic distance calculation result between two geographic points.
+"""
 type DistanceResult {
+  """
+  Geodesic distance between the two points in meters
+  """
   distance_meters: Float!
+  """
+  Origin latitude in decimal degrees
+  """
   from_lat: Float!
+  """
+  Origin longitude in decimal degrees
+  """
   from_lon: Float!
+  """
+  Destination latitude in decimal degrees
+  """
   to_lat: Float!
+  """
+  Destination longitude in decimal degrees
+  """
   to_lon: Float!
 }
 
+"""
+GPS points found within a named reference location's geofence radius.
+"""
 type WithinReferenceResult {
+  """
+  Name of the reference location searched
+  """
   reference_name: String!
+  """
+  Geofence radius used for the search in meters
+  """
   radius_meters: Float!
+  """
+  Number of GPS points found within the radius
+  """
   total_points: Int!
+  """
+  GPS points within the radius, sorted by distance
+  """
   points: [NearbyPoint!]!
+}
+
+"""
+Result payload returned when triggering an on-demand Garmin sync.
+"""
+type GarminSyncTriggerResult {
+  """
+  Sync trigger status (e.g. accepted, conflict, bad_request, error)
+  """
+  status: String!
+  """
+  Human-readable status message from upstream sync service
+  """
+  message: String!
+  """
+  True when a new sync run was accepted and triggered
+  """
+  accepted: Boolean!
+  """
+  UTC timestamp when sync was triggered
+  """
+  triggered_at: String
+  """
+  UTC timestamp when an already-running sync started
+  """
+  started_at: String
+  """
+  Effective sync window in hours
+  """
+  window_hours: Int
+  """
+  Window start timestamp computed by upstream service, when available
+  """
+  window_start: String
+  """
+  Effective lookback value, when provided
+  """
+  lookback: Int
 }
 
 # -------------------------------------------------------
 # Enums
 # -------------------------------------------------------
+"""
+Sort direction for query results.
+"""
 enum SortOrder {
+  """
+  Ascending order (oldest first, A-Z)
+  """
   asc
+  """
+  Descending order (newest first, Z-A)
+  """
   desc
 }
 
@@ -242,89 +1027,385 @@ enum SortOrder {
 # -------------------------------------------------------
 type Query {
   # Health
+  """
+  Get service health status.
+  """
   health: HealthStatus!
+  """
+  Get service readiness status including database connectivity.
+  """
   ready: ReadyStatus!
 
   # Locations
+  """
+  Retrieve a paginated list of OwnTracks location records.
+  """
   locations(
+    """
+    Filter by OwnTracks device identifier
+    """
     device_id: String
+    """
+    Start date filter (YYYY-MM-DD or ISO 8601)
+    """
     date_from: String
+    """
+    End date filter (YYYY-MM-DD or ISO 8601)
+    """
     date_to: String
+    """
+    Maximum number of items to return per page
+    """
     limit: Int
+    """
+    Number of items to skip for pagination
+    """
     offset: Int
+    """
+    Field name to sort by
+    """
     sort: String
+    """
+    Sort direction
+    """
     order: SortOrder
   ): LocationConnection!
 
-  location(id: Int!): LocationDetail
+  """
+  Retrieve a single location by its ID, including raw payload.
+  """
+  location(
+    """
+    Unique location record identifier
+    """
+    id: Int!
+  ): LocationDetail
 
+  """
+  List all distinct OwnTracks device identifiers.
+  """
   devices: [DeviceInfo!]!
 
-  locationCount(date: String, device_id: String): LocationCount!
+  """
+  Get aggregate count of location records with optional filters.
+  """
+  locationCount(
+    """
+    Filter by date (YYYY-MM-DD)
+    """
+    date: String
+    """
+    Filter by device identifier
+    """
+    device_id: String
+  ): LocationCount!
+
+  """
+  Get the earliest and latest location timestamps.
+  """
+  locationDateRange: LocationDateRange!
 
   # Garmin
+  """
+  Get the earliest and latest Garmin activity timestamps.
+  """
+  garminDateRange: GarminDateRange!
+
+  """
+  Retrieve a paginated list of Garmin activities.
+  """
   garminActivities(
+    """
+    Filter by sport type (e.g. cycling, running)
+    """
     sport: String
+    """
+    Start date filter (YYYY-MM-DD or ISO 8601)
+    """
     date_from: String
+    """
+    End date filter (YYYY-MM-DD or ISO 8601)
+    """
     date_to: String
+    """
+    Maximum number of items to return per page
+    """
     limit: Int
+    """
+    Number of items to skip for pagination
+    """
     offset: Int
+    """
+    Field name to sort by
+    """
     sort: String
+    """
+    Sort direction
+    """
     order: SortOrder
   ): GarminActivityConnection!
 
-  garminActivity(activity_id: String!): GarminActivity
-
-  garminTrackPoints(
+  """
+  Retrieve a single Garmin activity by its ID.
+  """
+  garminActivity(
+    """
+    Garmin Connect activity identifier
+    """
     activity_id: String!
+  ): GarminActivity
+
+  """
+  Retrieve paginated GPS track points for a Garmin activity.
+  """
+  garminTrackPoints(
+    """
+    Garmin Connect activity identifier
+    """
+    activity_id: String!
+    """
+    Maximum number of items to return per page
+    """
     limit: Int
+    """
+    Number of items to skip for pagination
+    """
     offset: Int
+    """
+    Field name to sort by
+    """
     sort: String
+    """
+    Sort direction
+    """
     order: SortOrder
+    """
+    Simplification tolerance for track point reduction
+    """
     simplify: Float
   ): GarminTrackPointConnection!
 
+  """
+  List all distinct sport types with activity counts.
+  """
   garminSports: [SportInfo!]!
 
-  # Unified GPS
-  unifiedGps(
-    source: String
+  """
+  Retrieve chart-optimised track points for a Garmin activity.
+  """
+  garminChartData(
+    """
+    Garmin Connect activity identifier
+    """
+    activity_id: String!
+  ): [GarminChartPoint!]!
+
+  """
+  Aggregate Garmin activity totals grouped by week, month, or year.
+  """
+  garminActivityTotals(
+    """
+    Aggregation period: 'week', 'month', or 'year'
+    """
+    period: String!
+    """
+    Filter by sport (e.g. cycling, running)
+    """
+    sport: String
+    """
+    Inclusive lower bound on activity start time (YYYY-MM-DD)
+    """
     date_from: String
+    """
+    Inclusive upper bound on activity start time (YYYY-MM-DD)
+    """
     date_to: String
+  ): [GarminActivityTotal!]!
+
+  # Unified GPS
+  """
+  Retrieve a paginated list of unified GPS points from all sources.
+  """
+  unifiedGps(
+    """
+    Filter by data source: 'owntracks' or 'garmin'
+    """
+    source: String
+    """
+    Start date filter (YYYY-MM-DD or ISO 8601)
+    """
+    date_from: String
+    """
+    End date filter (YYYY-MM-DD or ISO 8601)
+    """
+    date_to: String
+    """
+    Maximum number of items to return per page
+    """
     limit: Int
+    """
+    Number of items to skip for pagination
+    """
     offset: Int
+    """
+    Sort direction
+    """
     order: SortOrder
+    """
+    Exclude stationary points where speed is zero
+    """
+    exclude_stationary: Boolean
+    """
+    Remove points with duplicate coordinates (rounded to ~11m precision)
+    """
+    deduplicate: Boolean
   ): UnifiedGpsConnection!
 
+  """
+  Retrieve daily activity summaries combining OwnTracks and Garmin data.
+  """
   dailySummary(
+    """
+    Start date filter (YYYY-MM-DD or ISO 8601)
+    """
     date_from: String
+    """
+    End date filter (YYYY-MM-DD or ISO 8601)
+    """
     date_to: String
+    """
+    Maximum number of days to return per page
+    """
     limit: Int
-  ): [DailyActivitySummary!]!
+    """
+    Number of items to skip for pagination
+    """
+    offset: Int
+  ): DailySummaryConnection!
+
+  """
+  Get the earliest and latest activity dates available in the daily activity summary view.
+  """
+  dailySummaryDateRange: DailySummaryDateRange!
 
   # Reference Locations
+  """
+  List all named reference locations.
+  """
   referenceLocations: [ReferenceLocation!]!
-  referenceLocation(id: Int!): ReferenceLocation
+  """
+  Retrieve a single reference location by its ID.
+  """
+  referenceLocation(
+    """
+    Unique reference location identifier
+    """
+    id: Int!
+  ): ReferenceLocation
 
   # Spatial
+  """
+  Find GPS points within a radius of a geographic coordinate.
+  """
   nearbyPoints(
+    """
+    Center point latitude in decimal degrees
+    """
     lat: Float!
+    """
+    Center point longitude in decimal degrees
+    """
     lon: Float!
+    """
+    Search radius in meters
+    """
     radius_meters: Float
+    """
+    Filter by data source: 'owntracks' or 'garmin'
+    """
     source: String
+    """
+    Maximum number of points to return
+    """
     limit: Int
   ): [NearbyPoint!]!
 
+  """
+  Calculate the geodesic distance between two geographic points.
+  """
   calculateDistance(
+    """
+    Origin latitude in decimal degrees
+    """
     from_lat: Float!
+    """
+    Origin longitude in decimal degrees
+    """
     from_lon: Float!
+    """
+    Destination latitude in decimal degrees
+    """
     to_lat: Float!
+    """
+    Destination longitude in decimal degrees
+    """
     to_lon: Float!
   ): DistanceResult!
 
+  """
+  Find GPS points within a named reference location's geofence.
+  """
   withinReference(
+    """
+    Name of the reference location to search within
+    """
     name: String!
+    """
+    Filter by data source: 'owntracks' or 'garmin'
+    """
     source: String
+    """
+    Maximum number of points to return
+    """
     limit: Int
   ): WithinReferenceResult!
+
+  # Geocoding
+  """
+  Get geocoding coverage statistics.
+  """
+  geocodingStatus: GeocodingStatus!
+}
+
+# -------------------------------------------------------
+# Mutations
+# -------------------------------------------------------
+type Mutation {
+  """
+  Trigger an on-demand Garmin sync in the upstream API.
+  """
+  triggerGarminSync(
+    """
+    Optional sync window in hours. Preferred over lookback.
+    """
+    window_hours: Int
+    """
+    Optional legacy lookback value.
+    """
+    lookback: Int
+  ): GarminSyncTriggerResult!
+
+  """
+  Trigger batch reverse-geocoding of un-geocoded location records.
+  """
+  triggerGeocoding(
+    """
+    Number of locations to geocode in this batch (default 100)
+    """
+    batch_size: Int
+    """
+    Re-process previously failed location records (for example, those with status `no_coverage`)
+    """
+    retry_failed: Boolean
+  ): GeocodingTriggerResult!
 }

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -48,6 +48,28 @@ export type DailyActivitySummary = {
   total_duration_seconds?: Maybe<Scalars['Float']['output']>;
 };
 
+/** Paginated list of daily activity summaries. */
+export type DailySummaryConnection = {
+  __typename?: 'DailySummaryConnection';
+  /** List of daily activity summary items in the current page */
+  items: Array<DailyActivitySummary>;
+  /** Maximum number of items per page */
+  limit: Scalars['Int']['output'];
+  /** Number of items skipped from the start */
+  offset: Scalars['Int']['output'];
+  /** Total number of items matching the query */
+  total: Scalars['Int']['output'];
+};
+
+/** Earliest and latest activity dates available in the daily activity summary view. */
+export type DailySummaryDateRange = {
+  __typename?: 'DailySummaryDateRange';
+  /** Latest activity date with daily summary data (YYYY-MM-DD) */
+  max_date: Scalars['String']['output'];
+  /** Earliest activity date with daily summary data (YYYY-MM-DD) */
+  min_date: Scalars['String']['output'];
+};
+
 /** Distinct OwnTracks device identifier. */
 export type DeviceInfo = {
   __typename?: 'DeviceInfo';
@@ -478,7 +500,9 @@ export type Query = {
   /** Calculate the geodesic distance between two geographic points. */
   calculateDistance: DistanceResult;
   /** Retrieve daily activity summaries combining OwnTracks and Garmin data. */
-  dailySummary: Array<DailyActivitySummary>;
+  dailySummary: DailySummaryConnection;
+  /** Get the earliest and latest activity dates available in the daily activity summary view. */
+  dailySummaryDateRange: DailySummaryDateRange;
   /** List all distinct OwnTracks device identifiers. */
   devices: Array<DeviceInfo>;
   /** Retrieve a paginated list of Garmin activities. */
@@ -534,6 +558,7 @@ export type QueryDailySummaryArgs = {
   date_from?: InputMaybe<Scalars['String']['input']>;
   date_to?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -806,6 +831,8 @@ export type DirectiveResolverFn<TResult = Record<PropertyKey, never>, TParent = 
 export type ResolversTypes = ResolversObject<{
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   DailyActivitySummary: ResolverTypeWrapper<DailyActivitySummary>;
+  DailySummaryConnection: ResolverTypeWrapper<DailySummaryConnection>;
+  DailySummaryDateRange: ResolverTypeWrapper<DailySummaryDateRange>;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
   DeviceInfo: ResolverTypeWrapper<DeviceInfo>;
   DistanceResult: ResolverTypeWrapper<DistanceResult>;
@@ -847,6 +874,8 @@ export type ResolversTypes = ResolversObject<{
 export type ResolversParentTypes = ResolversObject<{
   Boolean: Scalars['Boolean']['output'];
   DailyActivitySummary: DailyActivitySummary;
+  DailySummaryConnection: DailySummaryConnection;
+  DailySummaryDateRange: DailySummaryDateRange;
   DateTime: Scalars['DateTime']['output'];
   DeviceInfo: DeviceInfo;
   DistanceResult: DistanceResult;
@@ -896,6 +925,18 @@ export type DailyActivitySummaryResolvers<ContextType = GatewayContext, ParentTy
   total_calories?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   total_distance_km?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_duration_seconds?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+}>;
+
+export type DailySummaryConnectionResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['DailySummaryConnection'] = ResolversParentTypes['DailySummaryConnection']> = ResolversObject<{
+  items?: Resolver<Array<ResolversTypes['DailyActivitySummary']>, ParentType, ContextType>;
+  limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  offset?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type DailySummaryDateRangeResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['DailySummaryDateRange'] = ResolversParentTypes['DailySummaryDateRange']> = ResolversObject<{
+  max_date?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  min_date?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 }>;
 
 export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
@@ -1126,7 +1167,8 @@ export type PaginationInfoResolvers<ContextType = GatewayContext, ParentType ext
 
 export type QueryResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
   calculateDistance?: Resolver<ResolversTypes['DistanceResult'], ParentType, ContextType, RequireFields<QueryCalculateDistanceArgs, 'from_lat' | 'from_lon' | 'to_lat' | 'to_lon'>>;
-  dailySummary?: Resolver<Array<ResolversTypes['DailyActivitySummary']>, ParentType, ContextType, Partial<QueryDailySummaryArgs>>;
+  dailySummary?: Resolver<ResolversTypes['DailySummaryConnection'], ParentType, ContextType, Partial<QueryDailySummaryArgs>>;
+  dailySummaryDateRange?: Resolver<ResolversTypes['DailySummaryDateRange'], ParentType, ContextType>;
   devices?: Resolver<Array<ResolversTypes['DeviceInfo']>, ParentType, ContextType>;
   garminActivities?: Resolver<ResolversTypes['GarminActivityConnection'], ParentType, ContextType, Partial<QueryGarminActivitiesArgs>>;
   garminActivity?: Resolver<Maybe<ResolversTypes['GarminActivity']>, ParentType, ContextType, RequireFields<QueryGarminActivityArgs, 'activity_id'>>;
@@ -1200,6 +1242,8 @@ export type WithinReferenceResultResolvers<ContextType = GatewayContext, ParentT
 
 export type Resolvers<ContextType = GatewayContext> = ResolversObject<{
   DailyActivitySummary?: DailyActivitySummaryResolvers<ContextType>;
+  DailySummaryConnection?: DailySummaryConnectionResolvers<ContextType>;
+  DailySummaryDateRange?: DailySummaryDateRangeResolvers<ContextType>;
   DateTime?: GraphQLScalarType;
   DeviceInfo?: DeviceInfoResolvers<ContextType>;
   DistanceResult?: DistanceResultResolvers<ContextType>;

--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -381,11 +381,28 @@ export class OtelDataAPI {
   }
 
   async getDailySummary(
-    params?: Nullable<{ date_from?: string; date_to?: string; limit?: number }>,
+    params?: Nullable<{
+      date_from?: string;
+      date_to?: string;
+      limit?: number;
+      offset?: number;
+    }>,
   ) {
-    return this.fetch<Schemas['DailyActivitySummary'][]>({
+    return this.fetch<{
+      items: Schemas['DailyActivitySummary'][];
+      total: number;
+      limit: number;
+      offset: number;
+    }>({
       path: '/api/v1/gps/daily-summary',
       query: params,
+      cacheTtlMs: 60_000,
+    });
+  }
+
+  async getDailySummaryDateRange() {
+    return this.fetch<{ min_date: string; max_date: string }>({
+      path: '/api/v1/gps/daily-summary/date-range',
       cacheTtlMs: 60_000,
     });
   }

--- a/src/resolvers/gps.ts
+++ b/src/resolvers/gps.ts
@@ -1,7 +1,7 @@
 import type { QueryResolvers } from '../__generated__/resolvers-types.js';
 
 export const gpsResolvers: {
-  Query: Pick<QueryResolvers, 'unifiedGps' | 'dailySummary'>;
+  Query: Pick<QueryResolvers, 'unifiedGps' | 'dailySummary' | 'dailySummaryDateRange'>;
 } = {
   Query: {
     unifiedGps: async (_parent, args, { dataSources }) => {
@@ -10,6 +10,10 @@ export const gpsResolvers: {
 
     dailySummary: async (_parent, args, { dataSources }) => {
       return dataSources.otelAPI.getDailySummary(args);
+    },
+
+    dailySummaryDateRange: async (_parent, _args, { dataSources }) => {
+      return dataSources.otelAPI.getDailySummaryDateRange();
     },
   },
 };

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -809,6 +809,42 @@ type DailyActivitySummary {
   total_calories: Int
 }
 
+"""
+Paginated list of daily activity summaries.
+"""
+type DailySummaryConnection {
+  """
+  List of daily activity summary items in the current page
+  """
+  items: [DailyActivitySummary!]!
+  """
+  Total number of items matching the query
+  """
+  total: Int!
+  """
+  Maximum number of items per page
+  """
+  limit: Int!
+  """
+  Number of items skipped from the start
+  """
+  offset: Int!
+}
+
+"""
+Earliest and latest activity dates available in the daily activity summary view.
+"""
+type DailySummaryDateRange {
+  """
+  Earliest activity date with daily summary data (YYYY-MM-DD)
+  """
+  min_date: String!
+  """
+  Latest activity date with daily summary data (YYYY-MM-DD)
+  """
+  max_date: String!
+}
+
 # -------------------------------------------------------
 # Reference Locations
 # -------------------------------------------------------
@@ -1238,10 +1274,19 @@ type Query {
     """
     date_to: String
     """
-    Maximum number of days to return
+    Maximum number of days to return per page
     """
     limit: Int
-  ): [DailyActivitySummary!]!
+    """
+    Number of items to skip for pagination
+    """
+    offset: Int
+  ): DailySummaryConnection!
+
+  """
+  Get the earliest and latest activity dates available in the daily activity summary view.
+  """
+  dailySummaryDateRange: DailySummaryDateRange!
 
   # Reference Locations
   """

--- a/tests/datasources/OtelDataAPI.test.ts
+++ b/tests/datasources/OtelDataAPI.test.ts
@@ -323,6 +323,7 @@ describe('OtelDataAPI', () => {
     await api.triggerGarminSync({ window_hours: 24 });
     await api.getUnifiedGps({ source: 'gps' });
     await api.getDailySummary({ limit: 3 });
+    await api.getDailySummaryDateRange();
     await api.getReferenceLocations();
     await api.getReferenceLocation(77);
     await api.getNearbyPoints({ lat: 1, lon: 2, radius_meters: 50, limit: 1, source: 'gps' });
@@ -350,6 +351,7 @@ describe('OtelDataAPI', () => {
       '/api/v1/garmin/sync',
       '/api/v1/gps/unified',
       '/api/v1/gps/daily-summary',
+      '/api/v1/gps/daily-summary/date-range',
       '/api/v1/reference-locations',
       '/api/v1/reference-locations/77',
       '/api/v1/spatial/nearby',

--- a/tests/resolvers/resolvers.test.ts
+++ b/tests/resolvers/resolvers.test.ts
@@ -220,14 +220,17 @@ describe('gps resolvers', () => {
   it('delegates unifiedGps and dailySummary queries', async () => {
     const ctx = contextWith({
       getUnifiedGps: mockAsync({ items: [] }),
-      getDailySummary: mockAsync([]),
+      getDailySummary: mockAsync({ items: [], total: 0, limit: 30, offset: 0 }),
+      getDailySummaryDateRange: mockAsync({ min_date: '2024-01-01', max_date: '2026-01-01' }),
     });
 
     await runResolver(gpsResolvers.Query.unifiedGps, { limit: 2, source: 'gps' }, ctx);
-    await runResolver(gpsResolvers.Query.dailySummary, { limit: 1 }, ctx);
+    await runResolver(gpsResolvers.Query.dailySummary, { limit: 1, offset: 0 }, ctx);
+    await runResolver(gpsResolvers.Query.dailySummaryDateRange, {}, ctx);
 
     expect(ctx.dataSources.otelAPI.getUnifiedGps).toHaveBeenCalledWith({ limit: 2, source: 'gps' });
-    expect(ctx.dataSources.otelAPI.getDailySummary).toHaveBeenCalledWith({ limit: 1 });
+    expect(ctx.dataSources.otelAPI.getDailySummary).toHaveBeenCalledWith({ limit: 1, offset: 0 });
+    expect(ctx.dataSources.otelAPI.getDailySummaryDateRange).toHaveBeenCalled();
   });
 
   it('forwards exclude_stationary and deduplicate args to data source', async () => {
@@ -359,6 +362,7 @@ describe('resolver index', () => {
         'garminChartData',
         'unifiedGps',
         'dailySummary',
+        'dailySummaryDateRange',
         'referenceLocations',
         'referenceLocation',
         'nearbyPoints',


### PR DESCRIPTION
## Summary

Adds pagination and a date-range query to the `dailySummary` GraphQL field so the UI can implement the same paging + calendar-filter pattern already used by Locations and Garmin Activities.

## Changes

- **Schema** (`src/schema/schema.graphql`)
  - `dailySummary` now returns `DailySummaryConnection!` (`items`, `total`, `limit`, `offset`) and accepts a new `offset: Int` argument.
  - New query `dailySummaryDateRange: DailySummaryDateRange!` returning `min_date` / `max_date` (YYYY-MM-DD).
- **Data source** (`src/datasources/OtelDataAPI.ts`)
  - `getDailySummary` accepts `offset` and returns the paginated envelope from the API.
  - New `getDailySummaryDateRange()` calling `GET /api/v1/gps/daily-summary/date-range` with 60s cache.
- **Resolvers** (`src/resolvers/gps.ts`)
  - Adds `dailySummaryDateRange` resolver delegating to the data source.
- **Tests** (`tests/datasources/OtelDataAPI.test.ts`, `tests/resolvers/resolvers.test.ts`)
  - Updated mocks/expectations for new shape and new query.
- **lint-staged** (`package.json`)
  - Pass `--no-warn-ignored` to ESLint so commits touching generated files (`src/__generated__/**`) no longer fail the pre-commit hook.

## Dependencies

- Requires [otel-data-api PR #98](https://github.com/stuartshay/otel-data-api/pull/98) to be merged and `@stuartshay/otel-data-types` republished to fully match the upstream OpenAPI types. The data source is currently typed with a structural shape so it works against the existing types package.

## Validation

- `npm run codegen` — regenerated `src/__generated__/resolvers-types.ts`.
- `npm run lint:all` — passes.
- `npm run type-check` — passes.
- `npm run test` — 47/47 passing.

## Next Steps

After merge and types republish, follow up with the `otel-data-ui` PR that wires the new pagination + date range into `DailySummaryPage`.

Refs stuartshay/otel-data-api#98