### PR TITLE
chore: housekeeping — VS Code jest settings + Renovate categorization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,7 +33,8 @@
     "**/dist": true
   },
   "jest.jestCommandLine": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-  "jest.rootPath": ".",
-  "jest.autoRun": "off",
-  "jest.showCoverageOnLoad": false
+  "jest.runMode": {
+    "type": "on-demand",
+    "coverage": false
+  }
 }

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -1,0 +1,150 @@
+# Renovate Configuration & Label Taxonomy
+
+This repo uses [Renovate](https://docs.renovatebot.com/) to keep dependencies
+up to date. The configuration lives in [`renovate.json`](../renovate.json) at
+the repo root.
+
+This document describes the label taxonomy, grouping strategy, and auto-merge
+rules so that PRs are easy to triage at a glance.
+
+---
+
+## Schedule & Limits
+
+| Setting               | Value                  |
+| --------------------- | ---------------------- |
+| Timezone              | `America/New_York`     |
+| Schedule              | `before 6am on Monday` |
+| `prHourlyLimit`       | `2`                    |
+| `prConcurrentLimit`   | `5`                    |
+| `dependencyDashboard` | `true`                 |
+
+A single **Dependency Dashboard** issue is maintained automatically — look for
+the issue titled _"🤖 Renovate Dependency Dashboard"_ in the Issues tab for a
+top-down view of all pending, blocked, and rate-limited updates.
+
+## Enabled Managers
+
+- `npm`
+- `dockerfile`
+- `github-actions`
+
+Other managers (e.g. `nvm`, `helm-values`) are intentionally disabled.
+
+---
+
+## Label Taxonomy
+
+Every Renovate PR receives the two base labels `dependencies` and `renovate`.
+Additional labels are added automatically based on **what is being updated** and
+**how risky the update is**.
+
+### Base labels (always applied)
+
+| Label          | Meaning                             |
+| -------------- | ----------------------------------- |
+| `dependencies` | PR updates one or more dependencies |
+| `renovate`     | PR was opened by the Renovate bot   |
+
+### Severity labels (by update type)
+
+| Label          | When applied                             | Auto-merge?             |
+| -------------- | ---------------------------------------- | ----------------------- |
+| `patch`        | SemVer patch bump (e.g. `1.2.3 → 1.2.4`) | ✅ npm, docker, actions |
+| `minor`        | SemVer minor bump (e.g. `1.2.3 → 1.3.0`) | ✅ docker, actions only |
+| `major`        | SemVer major bump (e.g. `1.x → 2.x`)     | ❌ never                |
+| `breaking`     | Added together with `major`              | ❌                      |
+| `needs-review` | Added to any major / vulnerability PR    | ❌                      |
+| `security`     | Added to vulnerability-alert PRs         | ❌ (prioritized)        |
+
+### Manager labels
+
+| Label            | Source                      |
+| ---------------- | --------------------------- |
+| `npm`            | `package.json` dependencies |
+| `docker`         | `Dockerfile` base image     |
+| `ci`             | `.github/workflows/*`       |
+| `github-actions` | `.github/workflows/*`       |
+
+### Ecosystem / scope labels (by package group)
+
+Each group adds context labels and a semantic-commit scope. Packages not
+listed here fall through to the default manager label only.
+
+- **`apollo-server`** — labels: `graphql`, `apollo`, `runtime` · scope:
+  `deps/apollo`
+  - `@apollo/server`, `@as-integrations/express5`, `graphql`, `graphql-tag`
+- **`graphql-codegen`** — labels: `graphql`, `codegen`, `dev-deps` · scope:
+  `deps/codegen`
+  - `@graphql-codegen/cli`, `@graphql-codegen/typescript`,
+    `@graphql-codegen/typescript-resolvers`
+- **`eslint`** — labels: `linting`, `dev-deps` · scope: `deps/eslint`
+  - `eslint`, `@eslint/js`, `typescript-eslint`, `globals`
+- **`jest`** — labels: `testing`, `dev-deps` · scope: `deps/testing`
+  - `jest`, `@jest/globals`, `ts-jest`
+- **`formatting-tools`** — labels: `formatting`, `dev-deps` · scope:
+  `deps/formatting`
+  - `cspell`, `prettier`, `markdownlint-cli2`, `husky`, `lint-staged`
+- **`typescript`** — labels: `typescript`, `dev-deps` · scope:
+  `deps/typescript`
+  - `typescript`, `tsx`, `@types/**`
+- **`newrelic`** — labels: `observability`, `runtime` · scope:
+  `deps/newrelic`
+  - `newrelic`, `@types/newrelic`
+- **`express`** — labels: `runtime` · scope: `deps/express`
+  - `express`, `cors`, `@types/express`, `@types/cors`
+- **`github-actions-*`** — labels: `ci`, `github-actions` · scope: `deps/ci`
+  - any action referenced in `.github/workflows/*`
+- **Docker** — labels: `docker` · scope: `deps/docker`
+  - `Dockerfile` base image updates
+
+---
+
+## Auto-merge Matrix
+
+| Manager        | Patch | Minor | Major |
+| -------------- | :---: | :---: | :---: |
+| npm            |  ✅   |  ❌   |  ❌   |
+| Dockerfile     |  ✅   |  ✅   |  ❌   |
+| GitHub Actions |  ✅   |  ✅   |  ❌   |
+
+Major updates **always** require a human review and carry the `needs-review`
+label. Vulnerability-driven updates carry `security` and are prioritized on the
+dashboard.
+
+---
+
+## Excluded Packages
+
+The `@stuartshay/*` packages (notably `@stuartshay/otel-data-types`) are
+**excluded from Renovate** because they are managed by the dedicated
+[`update-types.yml`](../.github/workflows/update-types.yml) workflow, which
+opens its own tagged PRs (`automated`, `types-update`, `otel-data-types`).
+
+---
+
+## Triage Cheat Sheet
+
+- **Quick merge candidates** — look for PRs labeled `patch` that auto-merged
+  themselves. If one sits unmerged, check CI.
+- **Needs attention this week** — filter by `needs-review` or `major`.
+- **Security-first** — filter by `security`; these jump the queue.
+- **Breaking but intentional** — `major` + `breaking` combined signals a
+  deliberate manual-review update.
+
+## Updating the Config
+
+1. Edit [`renovate.json`](../renovate.json).
+2. Validate locally (optional):
+
+   ```bash
+   npx --yes --package=renovate -- renovate-config-validator renovate.json
+   ```
+
+3. Open a PR; Renovate will re-read the config on the next run.
+
+## References
+
+- [Renovate configuration options](https://docs.renovatebot.com/configuration-options/)
+- [Renovate preset `config:recommended`](https://docs.renovatebot.com/presets-config/#configrecommended)
+- [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/)

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,8 @@
   "schedule": ["before 6am on Monday"],
   "prHourlyLimit": 2,
   "prConcurrentLimit": 5,
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "🤖 Renovate Dependency Dashboard",
   "enabledManagers": ["npm", "dockerfile", "github-actions"],
   "packageRules": [
     {
@@ -13,6 +15,25 @@
       "matchPackageNames": ["@stuartshay/**"],
       "enabled": false
     },
+
+    {
+      "description": "Severity label: patch updates",
+      "matchUpdateTypes": ["patch"],
+      "addLabels": ["patch"]
+    },
+    {
+      "description": "Severity label: minor updates",
+      "matchUpdateTypes": ["minor"],
+      "addLabels": ["minor"]
+    },
+    {
+      "description": "Severity label: major updates (require manual review)",
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["major", "breaking", "needs-review"],
+      "automerge": false,
+      "prPriority": 10
+    },
+
     {
       "description": "Auto-merge patch updates for npm dependencies",
       "matchManagers": ["npm"],
@@ -21,7 +42,31 @@
       "automergeType": "pr"
     },
     {
-      "description": "Group Apollo Server ecosystem",
+      "description": "npm major updates: no automerge, require manual review",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "addLabels": ["needs-review"]
+    },
+
+    {
+      "description": "Manager tag: npm",
+      "matchManagers": ["npm"],
+      "addLabels": ["npm"]
+    },
+    {
+      "description": "Manager tag: docker",
+      "matchManagers": ["dockerfile"],
+      "addLabels": ["docker"]
+    },
+    {
+      "description": "Manager tag: github-actions",
+      "matchManagers": ["github-actions"],
+      "addLabels": ["ci", "github-actions"]
+    },
+
+    {
+      "description": "Group Apollo Server / GraphQL runtime ecosystem",
       "matchPackageNames": [
         "@apollo/server",
         "@as-integrations/express5",
@@ -29,7 +74,9 @@
         "graphql-tag"
       ],
       "groupName": "apollo-server",
-      "groupSlug": "apollo-server"
+      "groupSlug": "apollo-server",
+      "addLabels": ["graphql", "apollo", "runtime"],
+      "semanticCommitScope": "deps/apollo"
     },
     {
       "description": "Group GraphQL Codegen",
@@ -39,39 +86,83 @@
         "@graphql-codegen/typescript-resolvers"
       ],
       "groupName": "graphql-codegen",
-      "groupSlug": "graphql-codegen"
+      "groupSlug": "graphql-codegen",
+      "addLabels": ["graphql", "codegen", "dev-deps"],
+      "semanticCommitScope": "deps/codegen"
     },
     {
       "description": "Group ESLint ecosystem",
-      "matchPackageNames": ["eslint", "@eslint/js", "typescript-eslint"],
+      "matchPackageNames": ["eslint", "@eslint/js", "typescript-eslint", "globals"],
       "groupName": "eslint",
-      "groupSlug": "eslint"
+      "groupSlug": "eslint",
+      "addLabels": ["linting", "dev-deps"],
+      "semanticCommitScope": "deps/eslint"
     },
     {
       "description": "Group Jest testing",
       "matchPackageNames": ["jest", "@jest/globals", "ts-jest"],
       "groupName": "jest",
-      "groupSlug": "jest"
+      "groupSlug": "jest",
+      "addLabels": ["testing", "dev-deps"],
+      "semanticCommitScope": "deps/testing"
     },
     {
-      "description": "Group formatting tools",
+      "description": "Group formatting / commit hook tooling",
       "matchPackageNames": ["cspell", "prettier", "markdownlint-cli2", "husky", "lint-staged"],
       "groupName": "formatting-tools",
-      "groupSlug": "formatting-tools"
+      "groupSlug": "formatting-tools",
+      "addLabels": ["formatting", "dev-deps"],
+      "semanticCommitScope": "deps/formatting"
     },
     {
-      "description": "Docker base image updates",
+      "description": "Group TypeScript compiler and type definitions",
+      "matchPackageNames": ["typescript", "tsx", "@types/**"],
+      "groupName": "typescript",
+      "groupSlug": "typescript",
+      "addLabels": ["typescript", "dev-deps"],
+      "semanticCommitScope": "deps/typescript"
+    },
+    {
+      "description": "Runtime dependency: New Relic APM agent",
+      "matchPackageNames": ["newrelic", "@types/newrelic"],
+      "groupName": "newrelic",
+      "groupSlug": "newrelic",
+      "addLabels": ["observability", "runtime"],
+      "semanticCommitScope": "deps/newrelic"
+    },
+    {
+      "description": "Runtime dependency: Express / CORS",
+      "matchPackageNames": ["express", "cors", "@types/express", "@types/cors"],
+      "groupName": "express",
+      "groupSlug": "express",
+      "addLabels": ["runtime"],
+      "semanticCommitScope": "deps/express"
+    },
+
+    {
+      "description": "Docker base image updates (minor/patch auto-merge)",
       "matchManagers": ["dockerfile"],
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "automerge": true,
+      "semanticCommitScope": "deps/docker"
     },
+    {
+      "description": "Docker base image major updates (manual review)",
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "addLabels": ["needs-review"],
+      "semanticCommitScope": "deps/docker"
+    },
+
     {
       "description": "GitHub Actions minor/patch updates (auto-merge)",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "github-actions-minor",
       "groupSlug": "github-actions-minor",
-      "automerge": true
+      "automerge": true,
+      "semanticCommitScope": "deps/ci"
     },
     {
       "description": "GitHub Actions major updates (manual review)",
@@ -79,7 +170,14 @@
       "matchUpdateTypes": ["major"],
       "groupName": "github-actions-major",
       "groupSlug": "github-actions-major",
-      "automerge": false
+      "automerge": false,
+      "addLabels": ["needs-review"],
+      "semanticCommitScope": "deps/ci"
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "addLabels": ["security", "needs-review"],
+    "prPriority": 20
+  }
 }


### PR DESCRIPTION
## Summary

Project housekeeping pass focused on two pain points:

1. **VS Code `.vscode/settings.json` was emitting deprecation warnings** from `orta.vscode-jest` v6+ (`jest.autoRun`, `jest.rootPath`, `jest.showCoverageOnLoad` are all deprecated).
2. **Renovate PRs were hard to triage** — every PR only got the generic `dependencies` + `renovate` labels regardless of scope (runtime vs dev, patch vs major, graphql vs linting, etc.).

## Changes

### `.vscode/settings.json`
- Remove deprecated `jest.autoRun`, `jest.rootPath`, `jest.showCoverageOnLoad`.
- Replace with the modern `jest.runMode` object schema (`on-demand`, coverage off).

### `renovate.json`
- Enable `dependencyDashboard` (single tracking issue in Issues tab).
- Add **severity labels**: `patch`, `minor`, `major`, `breaking`, `needs-review`.
- Add **manager labels**: `npm`, `docker`, `ci`, `github-actions`.
- Add **ecosystem labels + semantic commit scopes** for every package group:
  - `apollo-server` → `graphql`, `apollo`, `runtime` (scope `deps/apollo`)
  - `graphql-codegen` → `graphql`, `codegen`, `dev-deps` (scope `deps/codegen`)
  - `eslint` → `linting`, `dev-deps` (scope `deps/eslint`) — `globals` now included
  - `jest` → `testing`, `dev-deps` (scope `deps/testing`)
  - `formatting-tools` → `formatting`, `dev-deps` (scope `deps/formatting`)
  - `typescript` (new group) → `typescript`, `dev-deps` (scope `deps/typescript`)
  - `newrelic` (new group) → `observability`, `runtime` (scope `deps/newrelic`)
  - `express` (new group) → `runtime` (scope `deps/express`)
- **Disable automerge for npm major updates** (previously they flowed through with no distinct handling); label them `needs-review`.
- Split the Dockerfile rule into minor/patch (automerge) and major (manual review).
- Add `vulnerabilityAlerts` handler: tags PRs with `security` + `needs-review` and gives them priority.

### `docs/renovate.md` (new)
Documents the full label taxonomy, auto-merge matrix, and a triage cheat sheet so the rules are discoverable.

## Effect on open PRs

Once merged, the next Renovate run will **relabel existing PRs**. The 4 currently open PRs should pick up clearer tags:

| PR | Current labels | New labels (expected) |
|---|---|---|
| #74 `graphql-codegen (major)` | dependencies, renovate | + `major`, `breaking`, `needs-review`, `npm`, `graphql`, `codegen`, `dev-deps` |
| #73 `update eslint` | dependencies, renovate | + `major` or `minor`, `npm`, `linting`, `dev-deps` |
| #72 `globals v17.6.0` | dependencies, renovate | + `minor`, `npm`, `linting`, `dev-deps` |
| #70 `markdownlint-cli2 v0.22.1` | dependencies, renovate | + `patch`, `npm`, `formatting`, `dev-deps` |

## Validation

- ✅ `npx renovate-config-validator renovate.json` — no errors
- ✅ `npx markdownlint-cli2 docs/renovate.md` — 0 errors
- ✅ `npx cspell docs/renovate.md renovate.json` — clean
- ✅ JSON parse check on both `renovate.json` and `.vscode/settings.json`
- ✅ Pre-push hooks (cspell + detect-secrets) pass

## Notes for reviewer

- `newrelic_agent.log` was present in the workspace root as a local runtime artifact; it is **already covered by `*.log` in `.gitignore`** and has never been committed, so no repo change needed.
- Scope intentionally limited to `otel-data-gateway`. The same Renovate pattern can be rolled out to `otel-data-api`, `otel-data-ui`, and `otel-agents` in follow-up PRs.