### PR TITLE
feat(garmin): expose reverse-geocoded addresses via GraphQL

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -143,6 +143,45 @@ export interface GarminActivity {
   uploaded_at?: Maybe<Scalars['String']['output']>;
 }
 
+/** Full reverse-geocoded address attached to a Garmin activity waypoint. */
+export interface GarminActivityAddress {
+  __typename?: 'GarminActivityAddress';
+  /** Parent Garmin activity identifier */
+  activity_id: Scalars['String']['output'];
+  /** Pelias confidence score (0-1) */
+  confidence?: Maybe<Scalars['Float']['output']>;
+  /** Country name */
+  country?: Maybe<Scalars['String']['output']>;
+  /** Full formatted address label from Pelias */
+  display_address?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when geocoding was performed */
+  geocoded_at?: Maybe<Scalars['String']['output']>;
+  /** House or building number */
+  housenumber?: Maybe<Scalars['String']['output']>;
+  /** GPS latitude in decimal degrees (WGS 84) */
+  latitude: Scalars['Float']['output'];
+  /** City or town */
+  locality?: Maybe<Scalars['String']['output']>;
+  /** GPS longitude in decimal degrees (WGS 84) */
+  longitude: Scalars['Float']['output'];
+  /** Neighbourhood name */
+  neighbourhood?: Maybe<Scalars['String']['output']>;
+  /** Postal or ZIP code */
+  postalcode?: Maybe<Scalars['String']['output']>;
+  /** State or province */
+  region?: Maybe<Scalars['String']['output']>;
+  /** Geocoding status: success, no_coverage, error, pending */
+  status: Scalars['String']['output'];
+  /** Street name */
+  street?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp of the track point this address was derived from */
+  timestamp: Scalars['DateTime']['output'];
+  /** garmin_track_points.id this address was geocoded from */
+  track_point_id: Scalars['Int']['output'];
+  /** Role of this waypoint within the activity: start, end, or waypoint */
+  waypoint_kind: Scalars['String']['output'];
+}
+
 /** Paginated list of Garmin activities. */
 export interface GarminActivityConnection {
   __typename?: 'GarminActivityConnection';
@@ -231,6 +270,8 @@ export interface GarminTrackPoint {
   __typename?: 'GarminTrackPoint';
   /** Parent Garmin activity identifier */
   activity_id: Scalars['String']['output'];
+  /** Compact reverse-geocoded address summary, when geocoded */
+  address?: Maybe<GeocodedAddressSummary>;
   /** Elevation above sea level in meters */
   altitude?: Maybe<Scalars['Float']['output']>;
   /** Pedal/step cadence in RPM */
@@ -295,9 +336,43 @@ export interface GeocodedAddress {
   street?: Maybe<Scalars['String']['output']>;
 }
 
+/** Compact reverse-geocoded address summary embedded in track-point payloads. */
+export interface GeocodedAddressSummary {
+  __typename?: 'GeocodedAddressSummary';
+  /** Country name */
+  country?: Maybe<Scalars['String']['output']>;
+  /** Full formatted address label from Pelias */
+  display_address?: Maybe<Scalars['String']['output']>;
+  /** City or town */
+  locality?: Maybe<Scalars['String']['output']>;
+  /** State or province */
+  region?: Maybe<Scalars['String']['output']>;
+  /** Geocoding status: success, no_coverage, error, pending */
+  status: Scalars['String']['output'];
+  /** Role of this waypoint within a Garmin activity (start, end, waypoint). Null for OwnTracks records. */
+  waypoint_kind?: Maybe<Scalars['String']['output']>;
+}
+
+/** Coverage statistics for a single geocoding source (owntracks or garmin). */
+export interface GeocodingSourceStatus {
+  __typename?: 'GeocodingSourceStatus';
+  /** Number of records that failed geocoding */
+  errors: Scalars['Int']['output'];
+  /** Number of records outside Pelias coverage area */
+  no_coverage: Scalars['Int']['output'];
+  /** Number of records awaiting geocoding for this source */
+  pending: Scalars['Int']['output'];
+  /** Number of successfully geocoded records for this source */
+  success: Scalars['Int']['output'];
+  /** Total number of geocoded_addresses rows for this source */
+  total: Scalars['Int']['output'];
+}
+
 /** Coverage statistics for geocoded location records. */
 export interface GeocodingStatus {
   __typename?: 'GeocodingStatus';
+  /** Per-source breakdown of geocoding coverage (owntracks, garmin) */
+  by_source: GeocodingStatusBySource;
   /** Percentage of locations with a geocoded address */
   coverage_percent: Scalars['Float']['output'];
   /** Number of locations that failed geocoding */
@@ -312,6 +387,21 @@ export interface GeocodingStatus {
   success: Scalars['Int']['output'];
   /** Total number of OwnTracks location records */
   total_locations: Scalars['Int']['output'];
+}
+
+/** Per-source breakdown of geocoding coverage. */
+export interface GeocodingStatusBySource {
+  __typename?: 'GeocodingStatusBySource';
+  /** Coverage stats for Garmin rows */
+  garmin: GeocodingSourceStatus;
+  /** Number of Garmin activities that have at least one address row */
+  garmin_activities_geocoded: Scalars['Int']['output'];
+  /** Total number of Garmin activities (denominator for activity-level coverage) */
+  garmin_activities_total: Scalars['Int']['output'];
+  /** Percentage of Garmin activities with at least one geocoded address */
+  garmin_coverage_percent: Scalars['Float']['output'];
+  /** Coverage stats for OwnTracks rows */
+  owntracks: GeocodingSourceStatus;
 }
 
 /** Result of triggering a batch geocoding operation. */
@@ -499,6 +589,8 @@ export interface Query {
   garminActivities: GarminActivityConnection;
   /** Retrieve a single Garmin activity by its ID. */
   garminActivity?: Maybe<GarminActivity>;
+  /** Retrieve all reverse-geocoded addresses for a Garmin activity (start, mid-route waypoints, and end). */
+  garminActivityAddresses: Array<GarminActivityAddress>;
   /** Aggregate Garmin activity totals grouped by week, month, or year. */
   garminActivityTotals: Array<GarminActivityTotal>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
@@ -560,6 +652,10 @@ export interface QueryGarminActivitiesArgs {
 }
 
 export interface QueryGarminActivityArgs {
+  activity_id: Scalars['String']['input'];
+}
+
+export interface QueryGarminActivityAddressesArgs {
   activity_id: Scalars['String']['input'];
 }
 

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -146,6 +146,45 @@ export type GarminActivity = {
   uploaded_at?: Maybe<Scalars['String']['output']>;
 };
 
+/** Full reverse-geocoded address attached to a Garmin activity waypoint. */
+export type GarminActivityAddress = {
+  __typename?: 'GarminActivityAddress';
+  /** Parent Garmin activity identifier */
+  activity_id: Scalars['String']['output'];
+  /** Pelias confidence score (0-1) */
+  confidence?: Maybe<Scalars['Float']['output']>;
+  /** Country name */
+  country?: Maybe<Scalars['String']['output']>;
+  /** Full formatted address label from Pelias */
+  display_address?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when geocoding was performed */
+  geocoded_at?: Maybe<Scalars['String']['output']>;
+  /** House or building number */
+  housenumber?: Maybe<Scalars['String']['output']>;
+  /** GPS latitude in decimal degrees (WGS 84) */
+  latitude: Scalars['Float']['output'];
+  /** City or town */
+  locality?: Maybe<Scalars['String']['output']>;
+  /** GPS longitude in decimal degrees (WGS 84) */
+  longitude: Scalars['Float']['output'];
+  /** Neighbourhood name */
+  neighbourhood?: Maybe<Scalars['String']['output']>;
+  /** Postal or ZIP code */
+  postalcode?: Maybe<Scalars['String']['output']>;
+  /** State or province */
+  region?: Maybe<Scalars['String']['output']>;
+  /** Geocoding status: success, no_coverage, error, pending */
+  status: Scalars['String']['output'];
+  /** Street name */
+  street?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp of the track point this address was derived from */
+  timestamp: Scalars['DateTime']['output'];
+  /** garmin_track_points.id this address was geocoded from */
+  track_point_id: Scalars['Int']['output'];
+  /** Role of this waypoint within the activity: start, end, or waypoint */
+  waypoint_kind: Scalars['String']['output'];
+};
+
 /** Paginated list of Garmin activities. */
 export type GarminActivityConnection = {
   __typename?: 'GarminActivityConnection';
@@ -234,6 +273,8 @@ export type GarminTrackPoint = {
   __typename?: 'GarminTrackPoint';
   /** Parent Garmin activity identifier */
   activity_id: Scalars['String']['output'];
+  /** Compact reverse-geocoded address summary, when geocoded */
+  address?: Maybe<GeocodedAddressSummary>;
   /** Elevation above sea level in meters */
   altitude?: Maybe<Scalars['Float']['output']>;
   /** Pedal/step cadence in RPM */
@@ -298,9 +339,43 @@ export type GeocodedAddress = {
   street?: Maybe<Scalars['String']['output']>;
 };
 
+/** Compact reverse-geocoded address summary embedded in track-point payloads. */
+export type GeocodedAddressSummary = {
+  __typename?: 'GeocodedAddressSummary';
+  /** Country name */
+  country?: Maybe<Scalars['String']['output']>;
+  /** Full formatted address label from Pelias */
+  display_address?: Maybe<Scalars['String']['output']>;
+  /** City or town */
+  locality?: Maybe<Scalars['String']['output']>;
+  /** State or province */
+  region?: Maybe<Scalars['String']['output']>;
+  /** Geocoding status: success, no_coverage, error, pending */
+  status: Scalars['String']['output'];
+  /** Role of this waypoint within a Garmin activity (start, end, waypoint). Null for OwnTracks records. */
+  waypoint_kind?: Maybe<Scalars['String']['output']>;
+};
+
+/** Coverage statistics for a single geocoding source (owntracks or garmin). */
+export type GeocodingSourceStatus = {
+  __typename?: 'GeocodingSourceStatus';
+  /** Number of records that failed geocoding */
+  errors: Scalars['Int']['output'];
+  /** Number of records outside Pelias coverage area */
+  no_coverage: Scalars['Int']['output'];
+  /** Number of records awaiting geocoding for this source */
+  pending: Scalars['Int']['output'];
+  /** Number of successfully geocoded records for this source */
+  success: Scalars['Int']['output'];
+  /** Total number of geocoded_addresses rows for this source */
+  total: Scalars['Int']['output'];
+};
+
 /** Coverage statistics for geocoded location records. */
 export type GeocodingStatus = {
   __typename?: 'GeocodingStatus';
+  /** Per-source breakdown of geocoding coverage (owntracks, garmin) */
+  by_source: GeocodingStatusBySource;
   /** Percentage of locations with a geocoded address */
   coverage_percent: Scalars['Float']['output'];
   /** Number of locations that failed geocoding */
@@ -315,6 +390,21 @@ export type GeocodingStatus = {
   success: Scalars['Int']['output'];
   /** Total number of OwnTracks location records */
   total_locations: Scalars['Int']['output'];
+};
+
+/** Per-source breakdown of geocoding coverage. */
+export type GeocodingStatusBySource = {
+  __typename?: 'GeocodingStatusBySource';
+  /** Coverage stats for Garmin rows */
+  garmin: GeocodingSourceStatus;
+  /** Number of Garmin activities that have at least one address row */
+  garmin_activities_geocoded: Scalars['Int']['output'];
+  /** Total number of Garmin activities (denominator for activity-level coverage) */
+  garmin_activities_total: Scalars['Int']['output'];
+  /** Percentage of Garmin activities with at least one geocoded address */
+  garmin_coverage_percent: Scalars['Float']['output'];
+  /** Coverage stats for OwnTracks rows */
+  owntracks: GeocodingSourceStatus;
 };
 
 /** Result of triggering a batch geocoding operation. */
@@ -504,6 +594,8 @@ export type Query = {
   garminActivities: GarminActivityConnection;
   /** Retrieve a single Garmin activity by its ID. */
   garminActivity?: Maybe<GarminActivity>;
+  /** Retrieve all reverse-geocoded addresses for a Garmin activity (start, mid-route waypoints, and end). */
+  garminActivityAddresses: Array<GarminActivityAddress>;
   /** Aggregate Garmin activity totals grouped by week, month, or year. */
   garminActivityTotals: Array<GarminActivityTotal>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
@@ -569,6 +661,11 @@ export type QueryGarminActivitiesArgs = {
 
 
 export type QueryGarminActivityArgs = {
+  activity_id: Scalars['String']['input'];
+};
+
+
+export type QueryGarminActivityAddressesArgs = {
   activity_id: Scalars['String']['input'];
 };
 
@@ -833,6 +930,7 @@ export type ResolversTypes = ResolversObject<{
   DistanceResult: ResolverTypeWrapper<DistanceResult>;
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   GarminActivity: ResolverTypeWrapper<GarminActivity>;
+  GarminActivityAddress: ResolverTypeWrapper<GarminActivityAddress>;
   GarminActivityConnection: ResolverTypeWrapper<GarminActivityConnection>;
   GarminActivityTotal: ResolverTypeWrapper<GarminActivityTotal>;
   GarminChartPoint: ResolverTypeWrapper<GarminChartPoint>;
@@ -841,7 +939,10 @@ export type ResolversTypes = ResolversObject<{
   GarminTrackPoint: ResolverTypeWrapper<GarminTrackPoint>;
   GarminTrackPointConnection: ResolverTypeWrapper<GarminTrackPointConnection>;
   GeocodedAddress: ResolverTypeWrapper<GeocodedAddress>;
+  GeocodedAddressSummary: ResolverTypeWrapper<GeocodedAddressSummary>;
+  GeocodingSourceStatus: ResolverTypeWrapper<GeocodingSourceStatus>;
   GeocodingStatus: ResolverTypeWrapper<GeocodingStatus>;
+  GeocodingStatusBySource: ResolverTypeWrapper<GeocodingStatusBySource>;
   GeocodingTriggerResult: ResolverTypeWrapper<GeocodingTriggerResult>;
   HealthStatus: ResolverTypeWrapper<HealthStatus>;
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
@@ -876,6 +977,7 @@ export type ResolversParentTypes = ResolversObject<{
   DistanceResult: DistanceResult;
   Float: Scalars['Float']['output'];
   GarminActivity: GarminActivity;
+  GarminActivityAddress: GarminActivityAddress;
   GarminActivityConnection: GarminActivityConnection;
   GarminActivityTotal: GarminActivityTotal;
   GarminChartPoint: GarminChartPoint;
@@ -884,7 +986,10 @@ export type ResolversParentTypes = ResolversObject<{
   GarminTrackPoint: GarminTrackPoint;
   GarminTrackPointConnection: GarminTrackPointConnection;
   GeocodedAddress: GeocodedAddress;
+  GeocodedAddressSummary: GeocodedAddressSummary;
+  GeocodingSourceStatus: GeocodingSourceStatus;
   GeocodingStatus: GeocodingStatus;
+  GeocodingStatusBySource: GeocodingStatusBySource;
   GeocodingTriggerResult: GeocodingTriggerResult;
   HealthStatus: HealthStatus;
   Int: Scalars['Int']['output'];
@@ -980,6 +1085,26 @@ export type GarminActivityResolvers<ContextType = GatewayContext, ParentType ext
   uploaded_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
+export type GarminActivityAddressResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminActivityAddress'] = ResolversParentTypes['GarminActivityAddress']> = ResolversObject<{
+  activity_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  confidence?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  country?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  display_address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  geocoded_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  housenumber?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  latitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  locality?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  longitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  neighbourhood?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  postalcode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  region?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  street?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  timestamp?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  track_point_id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  waypoint_kind?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
 export type GarminActivityConnectionResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminActivityConnection'] = ResolversParentTypes['GarminActivityConnection']> = ResolversObject<{
   items?: Resolver<Array<ResolversTypes['GarminActivity']>, ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -1026,6 +1151,7 @@ export type GarminSyncTriggerResultResolvers<ContextType = GatewayContext, Paren
 
 export type GarminTrackPointResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminTrackPoint'] = ResolversParentTypes['GarminTrackPoint']> = ResolversObject<{
   activity_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  address?: Resolver<Maybe<ResolversTypes['GeocodedAddressSummary']>, ParentType, ContextType>;
   altitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   cadence?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   created_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -1060,7 +1186,25 @@ export type GeocodedAddressResolvers<ContextType = GatewayContext, ParentType ex
   street?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
+export type GeocodedAddressSummaryResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GeocodedAddressSummary'] = ResolversParentTypes['GeocodedAddressSummary']> = ResolversObject<{
+  country?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  display_address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  locality?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  region?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  waypoint_kind?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type GeocodingSourceStatusResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GeocodingSourceStatus'] = ResolversParentTypes['GeocodingSourceStatus']> = ResolversObject<{
+  errors?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  no_coverage?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  pending?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  success?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
 export type GeocodingStatusResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GeocodingStatus'] = ResolversParentTypes['GeocodingStatus']> = ResolversObject<{
+  by_source?: Resolver<ResolversTypes['GeocodingStatusBySource'], ParentType, ContextType>;
   coverage_percent?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   errors?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   geocoded?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -1068,6 +1212,14 @@ export type GeocodingStatusResolvers<ContextType = GatewayContext, ParentType ex
   pending?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   total_locations?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type GeocodingStatusBySourceResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GeocodingStatusBySource'] = ResolversParentTypes['GeocodingStatusBySource']> = ResolversObject<{
+  garmin?: Resolver<ResolversTypes['GeocodingSourceStatus'], ParentType, ContextType>;
+  garmin_activities_geocoded?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  garmin_activities_total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  garmin_coverage_percent?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  owntracks?: Resolver<ResolversTypes['GeocodingSourceStatus'], ParentType, ContextType>;
 }>;
 
 export type GeocodingTriggerResultResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GeocodingTriggerResult'] = ResolversParentTypes['GeocodingTriggerResult']> = ResolversObject<{
@@ -1167,6 +1319,7 @@ export type QueryResolvers<ContextType = GatewayContext, ParentType extends Reso
   devices?: Resolver<Array<ResolversTypes['DeviceInfo']>, ParentType, ContextType>;
   garminActivities?: Resolver<ResolversTypes['GarminActivityConnection'], ParentType, ContextType, Partial<QueryGarminActivitiesArgs>>;
   garminActivity?: Resolver<Maybe<ResolversTypes['GarminActivity']>, ParentType, ContextType, RequireFields<QueryGarminActivityArgs, 'activity_id'>>;
+  garminActivityAddresses?: Resolver<Array<ResolversTypes['GarminActivityAddress']>, ParentType, ContextType, RequireFields<QueryGarminActivityAddressesArgs, 'activity_id'>>;
   garminActivityTotals?: Resolver<Array<ResolversTypes['GarminActivityTotal']>, ParentType, ContextType, RequireFields<QueryGarminActivityTotalsArgs, 'period'>>;
   garminChartData?: Resolver<Array<ResolversTypes['GarminChartPoint']>, ParentType, ContextType, RequireFields<QueryGarminChartDataArgs, 'activity_id'>>;
   garminDateRange?: Resolver<ResolversTypes['GarminDateRange'], ParentType, ContextType>;
@@ -1243,6 +1396,7 @@ export type Resolvers<ContextType = GatewayContext> = ResolversObject<{
   DeviceInfo?: DeviceInfoResolvers<ContextType>;
   DistanceResult?: DistanceResultResolvers<ContextType>;
   GarminActivity?: GarminActivityResolvers<ContextType>;
+  GarminActivityAddress?: GarminActivityAddressResolvers<ContextType>;
   GarminActivityConnection?: GarminActivityConnectionResolvers<ContextType>;
   GarminActivityTotal?: GarminActivityTotalResolvers<ContextType>;
   GarminChartPoint?: GarminChartPointResolvers<ContextType>;
@@ -1251,7 +1405,10 @@ export type Resolvers<ContextType = GatewayContext> = ResolversObject<{
   GarminTrackPoint?: GarminTrackPointResolvers<ContextType>;
   GarminTrackPointConnection?: GarminTrackPointConnectionResolvers<ContextType>;
   GeocodedAddress?: GeocodedAddressResolvers<ContextType>;
+  GeocodedAddressSummary?: GeocodedAddressSummaryResolvers<ContextType>;
+  GeocodingSourceStatus?: GeocodingSourceStatusResolvers<ContextType>;
   GeocodingStatus?: GeocodingStatusResolvers<ContextType>;
+  GeocodingStatusBySource?: GeocodingStatusBySourceResolvers<ContextType>;
   GeocodingTriggerResult?: GeocodingTriggerResultResolvers<ContextType>;
   HealthStatus?: HealthStatusResolvers<ContextType>;
   JSON?: GraphQLScalarType;

--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -302,6 +302,33 @@ export class OtelDataAPI {
     });
   }
 
+  async getGarminActivityAddresses(activityId: string) {
+    return this.fetch<
+      {
+        track_point_id: number;
+        activity_id: string;
+        waypoint_kind: string;
+        timestamp: string;
+        latitude: number;
+        longitude: number;
+        display_address: string | null;
+        street: string | null;
+        housenumber: string | null;
+        neighbourhood: string | null;
+        locality: string | null;
+        region: string | null;
+        country: string | null;
+        postalcode: string | null;
+        confidence: number | null;
+        status: string;
+        geocoded_at: string | null;
+      }[]
+    >({
+      path: `/api/v1/garmin/activities/${activityId}/addresses`,
+      cacheTtlMs: 30_000,
+    });
+  }
+
   async getGarminActivityTotals(
     params: Nullable<{
       period: string;
@@ -466,6 +493,25 @@ export class OtelDataAPI {
       no_coverage: number;
       errors: number;
       coverage_percent: number;
+      by_source: {
+        owntracks: {
+          success: number;
+          pending: number;
+          no_coverage: number;
+          errors: number;
+          total: number;
+        };
+        garmin: {
+          success: number;
+          pending: number;
+          no_coverage: number;
+          errors: number;
+          total: number;
+        };
+        garmin_activities_total: number;
+        garmin_activities_geocoded: number;
+        garmin_coverage_percent: number;
+      };
     }>({ path: '/api/v1/geocoding/status', cacheTtlMs: 15_000 });
   }
 

--- a/src/resolvers/garmin.ts
+++ b/src/resolvers/garmin.ts
@@ -10,6 +10,7 @@ export const garminResolvers: {
     | 'garminSports'
     | 'garminChartData'
     | 'garminActivityTotals'
+    | 'garminActivityAddresses'
   >;
   Mutation: Pick<MutationResolvers, 'triggerGarminSync'>;
 } = {
@@ -41,6 +42,10 @@ export const garminResolvers: {
 
     garminActivityTotals: async (_parent, args, { dataSources }) => {
       return dataSources.otelAPI.getGarminActivityTotals(args);
+    },
+
+    garminActivityAddresses: async (_parent, args, { dataSources }) => {
+      return dataSources.otelAPI.getGarminActivityAddresses(args.activity_id);
     },
   },
   Mutation: {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -285,6 +285,62 @@ type GeocodingStatus {
   Percentage of locations with a geocoded address
   """
   coverage_percent: Float!
+  """
+  Per-source breakdown of geocoding coverage (owntracks, garmin)
+  """
+  by_source: GeocodingStatusBySource!
+}
+
+"""
+Coverage statistics for a single geocoding source (owntracks or garmin).
+"""
+type GeocodingSourceStatus {
+  """
+  Number of successfully geocoded records for this source
+  """
+  success: Int!
+  """
+  Number of records awaiting geocoding for this source
+  """
+  pending: Int!
+  """
+  Number of records outside Pelias coverage area
+  """
+  no_coverage: Int!
+  """
+  Number of records that failed geocoding
+  """
+  errors: Int!
+  """
+  Total number of geocoded_addresses rows for this source
+  """
+  total: Int!
+}
+
+"""
+Per-source breakdown of geocoding coverage.
+"""
+type GeocodingStatusBySource {
+  """
+  Coverage stats for OwnTracks rows
+  """
+  owntracks: GeocodingSourceStatus!
+  """
+  Coverage stats for Garmin rows
+  """
+  garmin: GeocodingSourceStatus!
+  """
+  Total number of Garmin activities (denominator for activity-level coverage)
+  """
+  garmin_activities_total: Int!
+  """
+  Number of Garmin activities that have at least one address row
+  """
+  garmin_activities_geocoded: Int!
+  """
+  Percentage of Garmin activities with at least one geocoded address
+  """
+  garmin_coverage_percent: Float!
 }
 
 """
@@ -574,6 +630,114 @@ type GarminTrackPoint {
   UTC timestamp when the record was inserted
   """
   created_at: String
+  """
+  Compact reverse-geocoded address summary, when geocoded
+  """
+  address: GeocodedAddressSummary
+}
+
+"""
+Compact reverse-geocoded address summary embedded in track-point payloads.
+"""
+type GeocodedAddressSummary {
+  """
+  Full formatted address label from Pelias
+  """
+  display_address: String
+  """
+  City or town
+  """
+  locality: String
+  """
+  State or province
+  """
+  region: String
+  """
+  Country name
+  """
+  country: String
+  """
+  Role of this waypoint within a Garmin activity (start, end, waypoint). Null for OwnTracks records.
+  """
+  waypoint_kind: String
+  """
+  Geocoding status: success, no_coverage, error, pending
+  """
+  status: String!
+}
+
+"""
+Full reverse-geocoded address attached to a Garmin activity waypoint.
+"""
+type GarminActivityAddress {
+  """
+  garmin_track_points.id this address was geocoded from
+  """
+  track_point_id: Int!
+  """
+  Parent Garmin activity identifier
+  """
+  activity_id: String!
+  """
+  Role of this waypoint within the activity: start, end, or waypoint
+  """
+  waypoint_kind: String!
+  """
+  UTC timestamp of the track point this address was derived from
+  """
+  timestamp: DateTime!
+  """
+  GPS latitude in decimal degrees (WGS 84)
+  """
+  latitude: Float!
+  """
+  GPS longitude in decimal degrees (WGS 84)
+  """
+  longitude: Float!
+  """
+  Full formatted address label from Pelias
+  """
+  display_address: String
+  """
+  Street name
+  """
+  street: String
+  """
+  House or building number
+  """
+  housenumber: String
+  """
+  Neighbourhood name
+  """
+  neighbourhood: String
+  """
+  City or town
+  """
+  locality: String
+  """
+  State or province
+  """
+  region: String
+  """
+  Country name
+  """
+  country: String
+  """
+  Postal or ZIP code
+  """
+  postalcode: String
+  """
+  Pelias confidence score (0-1)
+  """
+  confidence: Float
+  """
+  Geocoding status: success, no_coverage, error, pending
+  """
+  status: String!
+  """
+  UTC timestamp when geocoding was performed
+  """
+  geocoded_at: String
 }
 
 """
@@ -1199,6 +1363,16 @@ type Query {
     """
     activity_id: String!
   ): [GarminChartPoint!]!
+
+  """
+  Retrieve all reverse-geocoded addresses for a Garmin activity (start, mid-route waypoints, and end).
+  """
+  garminActivityAddresses(
+    """
+    Garmin Connect activity identifier
+    """
+    activity_id: String!
+  ): [GarminActivityAddress!]!
 
   """
   Aggregate Garmin activity totals grouped by week, month, or year.


### PR DESCRIPTION
## Summary

Phase 4 of the Garmin reverse-geocoding pipeline. Exposes the new otel-data-api endpoints to GraphQL clients (otel-data-ui).

## Schema changes

- **New types:**
  - `GarminActivityAddress` — full address rows for a Garmin activity (start, mid-route waypoints, end).
  - `GeocodedAddressSummary` — compact address embedded on track-point payloads.
  - `GeocodingSourceStatus` + `GeocodingStatusBySource` — per-source coverage breakdown.
- **Extended types:**
  - `GarminTrackPoint.address: GeocodedAddressSummary` (nullable).
  - `GeocodingStatus.by_source: GeocodingStatusBySource!` (required; matches API contract).
- **New query:**
  - `garminActivityAddresses(activity_id: String!): [GarminActivityAddress!]!` → `GET /api/v1/garmin/activities/:id/addresses`.

## Datasource

- Added `OtelDataAPI.getGarminActivityAddresses` with 30s cache TTL.
- Updated `getGeocodingStatus` inline type to include the new `by_source` block (npm `@stuartshay/otel-data-types` doesn't ship the field yet).

## Validation

- `npm run codegen` — clean
- `npm run type-check` — clean
- `npm run lint:all` — clean
- `npm test` — 51/51 pass
- `npm run build` — clean

## Refs

- Implementation issue: stuartshay/otel-data-api#110
- API merge (Phase 2): stuartshay/otel-data-api@fa72f56
- DB migrations (Phase 1): stuartshay/homelab-database-migrations@508be0f
- Agent worker (Phase 3): stuartshay/otel-agents@86dd33a