### PR TITLE
chore(renovate): avoid duplicate newrelic major/minor PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -127,6 +127,7 @@
       "matchPackageNames": ["newrelic", "@types/newrelic"],
       "groupName": "newrelic",
       "groupSlug": "newrelic",
+      "separateMajorMinor": false,
       "addLabels": ["observability", "runtime"],
       "semanticCommitScope": "deps/newrelic"
     },


### PR DESCRIPTION
## Summary
- set `separateMajorMinor: false` for the New Relic package rule
- keeps Renovate focused on a single highest-priority New Relic update PR instead of opening both minor and major at the same time

## Why
We currently see two concurrent New Relic dependency PRs (v13 minor and v14 major). This rule removes duplicate churn while preserving manual review for major upgrades.