### PR TITLE
feat: Extend GeocodedAddressSummary GraphQL type with detailed fields

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -339,16 +339,28 @@ export interface GeocodedAddress {
 /** Compact reverse-geocoded address summary embedded in track-point payloads. */
 export interface GeocodedAddressSummary {
   __typename?: 'GeocodedAddressSummary';
+  /** Pelias confidence score (0-1) */
+  confidence?: Maybe<Scalars['Float']['output']>;
   /** Country name */
   country?: Maybe<Scalars['String']['output']>;
   /** Full formatted address label from Pelias */
   display_address?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when geocoding was performed */
+  geocoded_at?: Maybe<Scalars['String']['output']>;
+  /** House or building number */
+  housenumber?: Maybe<Scalars['String']['output']>;
   /** City or town */
   locality?: Maybe<Scalars['String']['output']>;
+  /** Neighbourhood name */
+  neighbourhood?: Maybe<Scalars['String']['output']>;
+  /** Postal or ZIP code */
+  postalcode?: Maybe<Scalars['String']['output']>;
   /** State or province */
   region?: Maybe<Scalars['String']['output']>;
   /** Geocoding status: success, no_coverage, error, pending */
   status: Scalars['String']['output'];
+  /** Street name */
+  street?: Maybe<Scalars['String']['output']>;
   /** Role of this waypoint within a Garmin activity (start, end, waypoint). Null for OwnTracks records. */
   waypoint_kind?: Maybe<Scalars['String']['output']>;
 }

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -342,16 +342,28 @@ export type GeocodedAddress = {
 /** Compact reverse-geocoded address summary embedded in track-point payloads. */
 export type GeocodedAddressSummary = {
   __typename?: 'GeocodedAddressSummary';
+  /** Pelias confidence score (0-1) */
+  confidence?: Maybe<Scalars['Float']['output']>;
   /** Country name */
   country?: Maybe<Scalars['String']['output']>;
   /** Full formatted address label from Pelias */
   display_address?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when geocoding was performed */
+  geocoded_at?: Maybe<Scalars['String']['output']>;
+  /** House or building number */
+  housenumber?: Maybe<Scalars['String']['output']>;
   /** City or town */
   locality?: Maybe<Scalars['String']['output']>;
+  /** Neighbourhood name */
+  neighbourhood?: Maybe<Scalars['String']['output']>;
+  /** Postal or ZIP code */
+  postalcode?: Maybe<Scalars['String']['output']>;
   /** State or province */
   region?: Maybe<Scalars['String']['output']>;
   /** Geocoding status: success, no_coverage, error, pending */
   status: Scalars['String']['output'];
+  /** Street name */
+  street?: Maybe<Scalars['String']['output']>;
   /** Role of this waypoint within a Garmin activity (start, end, waypoint). Null for OwnTracks records. */
   waypoint_kind?: Maybe<Scalars['String']['output']>;
 };
@@ -1187,11 +1199,17 @@ export type GeocodedAddressResolvers<ContextType = GatewayContext, ParentType ex
 }>;
 
 export type GeocodedAddressSummaryResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GeocodedAddressSummary'] = ResolversParentTypes['GeocodedAddressSummary']> = ResolversObject<{
+  confidence?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   country?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   display_address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  geocoded_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  housenumber?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   locality?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  neighbourhood?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  postalcode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   region?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  street?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   waypoint_kind?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -645,6 +645,18 @@ type GeocodedAddressSummary {
   """
   display_address: String
   """
+  Street name
+  """
+  street: String
+  """
+  House or building number
+  """
+  housenumber: String
+  """
+  Neighbourhood name
+  """
+  neighbourhood: String
+  """
   City or town
   """
   locality: String
@@ -657,6 +669,14 @@ type GeocodedAddressSummary {
   """
   country: String
   """
+  Postal or ZIP code
+  """
+  postalcode: String
+  """
+  Pelias confidence score (0-1)
+  """
+  confidence: Float
+  """
   Role of this waypoint within a Garmin activity (start, end, waypoint). Null for OwnTracks records.
   """
   waypoint_kind: String
@@ -664,6 +684,10 @@ type GeocodedAddressSummary {
   Geocoding status: success, no_coverage, error, pending
   """
   status: String!
+  """
+  UTC timestamp when geocoding was performed
+  """
+  geocoded_at: String
 }
 
 """


### PR DESCRIPTION
## Summary
Extends the `GeocodedAddressSummary` GraphQL type to include detailed address fields that map to the updated API model, enabling full address data in export functionality.

## Changes
- Extended `GeocodedAddressSummary` GraphQL type with 6 new fields:
  - `street: String`
  - `housenumber: String`
  - `neighbourhood: String`
  - `postalcode: String`
  - `confidence: Float`
  - `geocoded_at: String` (ISO 8601 timestamp)

- Regenerated TypeScript resolver types via `npm run codegen`

## Testing
- GraphQL schema validation passes
- TypeScript type generation passes (`npm run type-check`)

## Related Repos
- otel-data-api: PR to extend API model and database query
- otel-data-ui: PR to add export functionality

## Deployment Order
Requires otel-data-api deployed first, then this PR, then otel-data-ui