### PR TITLE
[codex] Expose Garmin chart respiration rate

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -255,6 +255,8 @@ export interface GarminChartPoint {
   latitude: Scalars['Float']['output'];
   /** GPS longitude in decimal degrees (WGS 84) */
   longitude: Scalars['Float']['output'];
+  /** Respiration rate in breaths per minute */
+  respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Instantaneous speed in km/h */
   speed_kmh?: Maybe<Scalars['Float']['output']>;
   /** Ambient temperature in degrees C */

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -258,6 +258,8 @@ export type GarminChartPoint = {
   latitude: Scalars['Float']['output'];
   /** GPS longitude in decimal degrees (WGS 84) */
   longitude: Scalars['Float']['output'];
+  /** Respiration rate in breaths per minute */
+  respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Instantaneous speed in km/h */
   speed_kmh?: Maybe<Scalars['Float']['output']>;
   /** Ambient temperature in degrees C */
@@ -1182,6 +1184,7 @@ export type GarminChartPointResolvers<ContextType = GatewayContext, ParentType e
   heart_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   latitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   longitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  respiration_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   speed_kmh?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   temperature_c?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   timestamp?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -881,6 +881,10 @@ type GarminChartPoint {
   """
   heart_rate: Int
   """
+  Respiration rate in breaths per minute
+  """
+  respiration_rate: Int
+  """
   Pedal/step cadence in RPM
   """
   cadence: Int

--- a/tests/schema/typeDefs.test.ts
+++ b/tests/schema/typeDefs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
+import { buildSchema, graphql } from 'graphql';
 import typeDefs from '../../src/schema/typeDefs.js';
 
 describe('typeDefs', () => {
@@ -8,5 +9,44 @@ describe('typeDefs', () => {
     expect(typeDefs).toContain('health');
     expect(typeDefs).toContain('garminActivities');
     expect(typeDefs).toContain('triggerGarminSync');
+  });
+
+  it('exposes respiration rate on Garmin chart points', async () => {
+    const schema = buildSchema(typeDefs);
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          garminChartData(activity_id: "activity-1") {
+            timestamp
+            latitude
+            longitude
+            respiration_rate
+          }
+        }
+      `,
+      rootValue: {
+        garminChartData: () => [
+          {
+            timestamp: '2026-06-19T12:00:00Z',
+            latitude: 40.7,
+            longitude: -74,
+            respiration_rate: 27,
+          },
+        ],
+      },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      garminChartData: [
+        {
+          timestamp: '2026-06-19T12:00:00Z',
+          latitude: 40.7,
+          longitude: -74,
+          respiration_rate: 27,
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
## Summary

Refs #126

Expose `respiration_rate` on `GarminChartPoint` so UI chart queries can consume
the per-track-point respiration values already returned by otel-data-api.

Generated resolver and publishable package types are updated from the schema.
A GraphQL execution test verifies the field can be selected and serialized.

## Root Cause

The REST chart-data endpoint already returned respiration values, but the
gateway schema omitted the field. GraphQL therefore rejected the UI query
before the activity chart resolver could run.

## Validation

- `npm run lint:all` — PASS
- `npm test -- --runInBand` — PASS, 56/56 tests
- `npm run type-check` — PASS
- `npm run build` — PASS
- Local GraphQL query against activity `23300698725` — PASS, 9,435 non-null
  respiration samples
- UI Playwright regression using the local gateway — PASS

## Downstream

- UI issue: stuartshay/otel-data-ui#204
- The UI PR must be deployed after this gateway schema change.
- After merge, verify the published `@stuartshay/otel-graphql-types` update PR
  is created in otel-data-ui and passes CI.

## Post-Merge Validation

- [ ] Gateway image built and deployed
- [ ] Production GraphQL query accepts `respiration_rate`
- [ ] Downstream GraphQL types PR verified
- [ ] UI Respiration Rate chart validated after deployment

The issue remains open until deployed acceptance validation is complete.
