### PR TITLE
[codex] Hold GraphQL at v16 in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,11 @@
       "matchPackageNames": ["@stuartshay/**"],
       "enabled": false
     },
+    {
+      "description": "Hold GraphQL at v16 until dependent tooling supports v17",
+      "matchPackageNames": ["graphql"],
+      "allowedVersions": "<17"
+    },
 
     {
       "description": "Severity label: patch updates",


### PR DESCRIPTION
## Summary

- constrain Renovate-managed `graphql` updates to versions below 17
- continue allowing compatible GraphQL 16 patch releases
- prevent repeated invalid GraphQL 17 PR refreshes and failing CI runs

## Root cause

GraphQL 17 is published, but `@apollo/server@5.5.1` requires GraphQL `^16.11.0`, and the current GraphQL Codegen packages declare peer support only through GraphQL 16. Renovate cannot produce a valid lockfile for PR #125, and CI fails during `npm ci`.

## Validation

- `RENOVATE_CONFIG_FILE=renovate.json npx --yes --package renovate renovate-config-validator --strict`
- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm test -- --runInBand` — 56 tests passed
- `npm audit --audit-level=moderate` — reports 26 existing findings; remediation is excluded from this targeted configuration PR

## Dependency scope

No package versions or generated files are changed. Other outdated packages remain managed by existing Renovate groups, and `@stuartshay/*` remains excluded for its dedicated update workflow. This configuration supersedes the incompatible update proposed by #125 after Renovate reevaluates it.

Refs #128
Refs #125