### PR TITLE
[codex] Expose extended Garmin track-point fields

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -310,16 +310,24 @@ export interface GarminTrackPoint {
   created_at?: Maybe<Scalars['String']['output']>;
   /** Cumulative distance from activity start in km */
   distance_from_start_km?: Maybe<Scalars['Float']['output']>;
+  /** Effort classification label */
+  effort_level?: Maybe<Scalars['String']['output']>;
   /** Heart rate in beats per minute */
   heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Heart-rate zone index (1-5) */
+  hr_zone?: Maybe<Scalars['Int']['output']>;
   /** Unique track point record identifier */
   id: Scalars['Int']['output'];
   /** GPS latitude in decimal degrees (WGS 84) */
   latitude: Scalars['Float']['output'];
   /** GPS longitude in decimal degrees (WGS 84) */
   longitude: Scalars['Float']['output'];
+  /** Respiration rate in breaths per minute */
+  respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Instantaneous speed in km/h */
   speed_kmh?: Maybe<Scalars['Float']['output']>;
+  /** Road or terrain type */
+  surface_type?: Maybe<Scalars['String']['output']>;
   /** Ambient temperature in degrees C */
   temperature_c?: Maybe<Scalars['Float']['output']>;
   /** UTC timestamp of the track point recording */

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -313,16 +313,24 @@ export type GarminTrackPoint = {
   created_at?: Maybe<Scalars['String']['output']>;
   /** Cumulative distance from activity start in km */
   distance_from_start_km?: Maybe<Scalars['Float']['output']>;
+  /** Effort classification label */
+  effort_level?: Maybe<Scalars['String']['output']>;
   /** Heart rate in beats per minute */
   heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Heart-rate zone index (1-5) */
+  hr_zone?: Maybe<Scalars['Int']['output']>;
   /** Unique track point record identifier */
   id: Scalars['Int']['output'];
   /** GPS latitude in decimal degrees (WGS 84) */
   latitude: Scalars['Float']['output'];
   /** GPS longitude in decimal degrees (WGS 84) */
   longitude: Scalars['Float']['output'];
+  /** Respiration rate in breaths per minute */
+  respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Instantaneous speed in km/h */
   speed_kmh?: Maybe<Scalars['Float']['output']>;
+  /** Road or terrain type */
+  surface_type?: Maybe<Scalars['String']['output']>;
   /** Ambient temperature in degrees C */
   temperature_c?: Maybe<Scalars['Float']['output']>;
   /** UTC timestamp of the track point recording */
@@ -1213,11 +1221,15 @@ export type GarminTrackPointResolvers<ContextType = GatewayContext, ParentType e
   cadence?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   created_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   distance_from_start_km?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  effort_level?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   heart_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  hr_zone?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   latitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   longitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  respiration_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   speed_kmh?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  surface_type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   temperature_c?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   timestamp?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
 }>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -675,6 +675,14 @@ type GarminTrackPoint {
   """
   heart_rate: Int
   """
+  Heart-rate zone index (1-5)
+  """
+  hr_zone: Int
+  """
+  Respiration rate in breaths per minute
+  """
+  respiration_rate: Int
+  """
   Pedal/step cadence in RPM
   """
   cadence: Int
@@ -682,6 +690,14 @@ type GarminTrackPoint {
   Ambient temperature in degrees C
   """
   temperature_c: Float
+  """
+  Road or terrain type
+  """
+  surface_type: String
+  """
+  Effort classification label
+  """
+  effort_level: String
   """
   UTC timestamp when the record was inserted
   """

--- a/tests/schema/typeDefs.test.ts
+++ b/tests/schema/typeDefs.test.ts
@@ -49,4 +49,49 @@ describe('typeDefs', () => {
       ],
     });
   });
+
+  it('exposes extended metrics on Garmin track points', async () => {
+    const schema = buildSchema(typeDefs);
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          garminTrackPoints(activity_id: "activity-1") {
+            items {
+              hr_zone
+              respiration_rate
+              surface_type
+              effort_level
+            }
+          }
+        }
+      `,
+      rootValue: {
+        garminTrackPoints: () => ({
+          items: [
+            {
+              hr_zone: 3,
+              respiration_rate: 27,
+              surface_type: 'paved',
+              effort_level: 'steady',
+            },
+          ],
+        }),
+      },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      garminTrackPoints: {
+        items: [
+          {
+            hr_zone: 3,
+            respiration_rate: 27,
+            surface_type: 'paved',
+            effort_level: 'steady',
+          },
+        ],
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- expose `hr_zone`, `respiration_rate`, `surface_type`, and `effort_level` on `GarminTrackPoint`
- regenerate internal resolver types and publishable `@stuartshay/otel-graphql-types` declarations
- add an executable GraphQL schema test covering all four fields

## Root cause

The REST API already returned these activity-point fields and otel-data-ui#211 deployed export support for them, but the production gateway schema did not expose them. GraphQL therefore rejected the UI export query before any CSV or GeoJSON could be generated.

## Impact

Once this gateway version is deployed, the existing UI `1.0.687` export query can retrieve the extended point metrics. Nullable fields pass through unchanged when the API has no value.

## Validation

- `npm test -- --runInBand` — 5 suites / 57 tests passed
- coverage — 90.24% statements, 82.27% branches, 90% functions, 91.13% lines
- `npm run lint:all` — passed
- `npm run type-check` — passed
- `npm run build` — passed

## Required follow-up after merge

1. Publish a gateway GitHub release so `@stuartshay/otel-graphql-types` is generated and published.
2. Verify the automated dependency PR in `otel-data-ui` updates the package to that release version and passes CI.
3. Deploy the gateway image through the generated `k8s-gitops` PR.
4. Revalidate the live gateway schema and CSV/GeoJSON exports before closing the issue.

Refs #130
Related: stuartshay/otel-data-ui#210 and stuartshay/otel-data-ui#211