### PR TITLE
fix(garmin): expose hr_zone on GarminChartPoint

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -251,6 +251,8 @@ export interface GarminChartPoint {
   distance_from_start_km?: Maybe<Scalars['Float']['output']>;
   /** Heart rate in beats per minute */
   heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Heart-rate zone index (1-5) */
+  hr_zone?: Maybe<Scalars['Int']['output']>;
   /** GPS latitude in decimal degrees (WGS 84) */
   latitude: Scalars['Float']['output'];
   /** GPS longitude in decimal degrees (WGS 84) */

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -254,6 +254,8 @@ export type GarminChartPoint = {
   distance_from_start_km?: Maybe<Scalars['Float']['output']>;
   /** Heart rate in beats per minute */
   heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Heart-rate zone index (1-5) */
+  hr_zone?: Maybe<Scalars['Int']['output']>;
   /** GPS latitude in decimal degrees (WGS 84) */
   latitude: Scalars['Float']['output'];
   /** GPS longitude in decimal degrees (WGS 84) */
@@ -1190,6 +1192,7 @@ export type GarminChartPointResolvers<ContextType = GatewayContext, ParentType e
   cadence?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   distance_from_start_km?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   heart_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  hr_zone?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   latitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   longitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   respiration_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -897,6 +897,10 @@ type GarminChartPoint {
   """
   heart_rate: Int
   """
+  Heart-rate zone index (1-5)
+  """
+  hr_zone: Int
+  """
   Respiration rate in breaths per minute
   """
   respiration_rate: Int

--- a/tests/schema/typeDefs.test.ts
+++ b/tests/schema/typeDefs.test.ts
@@ -11,7 +11,7 @@ describe('typeDefs', () => {
     expect(typeDefs).toContain('triggerGarminSync');
   });
 
-  it('exposes respiration rate on Garmin chart points', async () => {
+  it('exposes heart-rate zone and respiration rate on Garmin chart points', async () => {
     const schema = buildSchema(typeDefs);
     const result = await graphql({
       schema,
@@ -21,6 +21,7 @@ describe('typeDefs', () => {
             timestamp
             latitude
             longitude
+            hr_zone
             respiration_rate
           }
         }
@@ -31,6 +32,7 @@ describe('typeDefs', () => {
             timestamp: '2026-06-19T12:00:00Z',
             latitude: 40.7,
             longitude: -74,
+            hr_zone: 3,
             respiration_rate: 27,
           },
         ],
@@ -44,6 +46,7 @@ describe('typeDefs', () => {
           timestamp: '2026-06-19T12:00:00Z',
           latitude: 40.7,
           longitude: -74,
+          hr_zone: 3,
           respiration_rate: 27,
         },
       ],


### PR DESCRIPTION
## Summary

- add `hr_zone: Int` to the `GarminChartPoint` GraphQL type in `schema.graphql`
- regenerate internal resolver types (`src/__generated__/resolvers-types.ts`) and publishable `@stuartshay/otel-graphql-types` declarations (`packages/graphql-types/index.d.ts`)
- extend the chart-point schema test to assert `hr_zone` resolves

## Root cause

The deployed UI's `garminChartData` query requests `hr_zone` on `GarminChartPoint`, but the gateway schema only added the extended fields to `GarminTrackPoint` in #131 — `GarminChartPoint` was missed. The deployed gateway (`1.0.370`) therefore rejected the query with:

```
Chart data failed: Cannot query field "hr_zone" on type "GarminChartPoint".
```

This broke the Garmin Activity charts in production (the Route map still rendered, but the chart panel errored).

The REST API already returns `hr_zone` in chart-data (`app/models/garmin.py` `GarminChartPoint.hr_zone`, selected in the `/chart-data` query), so the resolver pass-through populates the value once the schema exposes it. `respiration_rate` was already present on `GarminChartPoint`; only `hr_zone` was missing and is the only field the deployed UI queries that wasn't exposed.

## Validation

- `npm test -- --runInBand` — 5 suites / 57 tests passed; coverage 90.24% stmts / 82.27% branches / 90% funcs / 91.13% lines
- `npm run type-check` — passed
- `npm run lint:all` — passed
- `npm run build` — passed; verified `dist/schema/schema.graphql` exposes `hr_zone` on `GarminChartPoint`

## Required follow-up after merge

1. Cut a gateway release so `@stuartshay/otel-graphql-types` republishes with `hr_zone` on `GarminChartPoint`.
2. Verify the auto-created dependency-update PR in `otel-data-ui` (and confirm CI is green).
3. Deploy the new gateway image via the generated `k8s-gitops` PR (bump from `1.0.370`).
4. Revalidate the live schema and the Garmin Activity chart before closing.

Refs #130, #131