### PR TITLE
[codex] Expose Garmin total strokes in GraphQL

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -159,6 +159,8 @@ export interface GarminActivity {
   total_elapsed_time?: Maybe<Scalars['Float']['output']>;
   /** Total intensity minutes */
   total_intensity_minutes?: Maybe<Scalars['Int']['output']>;
+  /** Total activity strokes */
+  total_strokes?: Maybe<Scalars['Int']['output']>;
   /** Total timer time in seconds (active recording) */
   total_timer_time?: Maybe<Scalars['Float']['output']>;
   /** Number of GPS track points in this activity */

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -162,6 +162,8 @@ export type GarminActivity = {
   total_elapsed_time?: Maybe<Scalars['Float']['output']>;
   /** Total intensity minutes */
   total_intensity_minutes?: Maybe<Scalars['Int']['output']>;
+  /** Total activity strokes */
+  total_strokes?: Maybe<Scalars['Int']['output']>;
   /** Total timer time in seconds (active recording) */
   total_timer_time?: Maybe<Scalars['Float']['output']>;
   /** Number of GPS track points in this activity */
@@ -1144,6 +1146,7 @@ export type GarminActivityResolvers<ContextType = GatewayContext, ParentType ext
   total_distance?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_elapsed_time?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_intensity_minutes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  total_strokes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   total_timer_time?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   track_point_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   unpaved_distance_km?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -533,6 +533,10 @@ type GarminActivity {
   """
   max_cadence: Int
   """
+  Total activity strokes
+  """
+  total_strokes: Int
+  """
   Total calories burned
   """
   calories: Int

--- a/tests/schema/typeDefs.test.ts
+++ b/tests/schema/typeDefs.test.ts
@@ -9,6 +9,7 @@ describe('typeDefs', () => {
     expect(typeDefs).toContain('health');
     expect(typeDefs).toContain('garminActivities');
     expect(typeDefs).toContain('triggerGarminSync');
+    expect(typeDefs).toContain('total_strokes: Int');
   });
 
   it('exposes heart-rate zone and respiration rate on Garmin chart points', async () => {


### PR DESCRIPTION
## What changed

- add `total_strokes` to the Garmin activity GraphQL type
- regenerate resolver and published GraphQL types
- add schema regression coverage

## Why

The GraphQL contract must carry the new Garmin activity metric from the data API to the UI.

## Validation

- 57 tests passed
- lint, typecheck, coverage, and build passed
- deployed GraphQL schema exposes `GarminActivity.total_strokes`

Refs #134
