### PR TITLE
feat(garmin): expose per-point Garmin metrics on activity detail (slice 1)

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -19,6 +19,7 @@
     "loadtest",
     "lookback",
     "markdownlint",
+    "millilitres",
     "mqtt",
     "neighbourhood",
     "newrelic",

--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -249,14 +249,22 @@ export interface GarminChartPoint {
   cadence?: Maybe<Scalars['Int']['output']>;
   /** Cumulative distance from activity start in km */
   distance_from_start_km?: Maybe<Scalars['Float']['output']>;
+  /** Effort classification label */
+  effort_level?: Maybe<Scalars['String']['output']>;
   /** Heart rate in beats per minute */
   heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Heart-rate zone index (1-5) */
+  hr_zone?: Maybe<Scalars['Int']['output']>;
   /** GPS latitude in decimal degrees (WGS 84) */
   latitude: Scalars['Float']['output'];
   /** GPS longitude in decimal degrees (WGS 84) */
   longitude: Scalars['Float']['output'];
+  /** Respiration rate in breaths per minute */
+  respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Instantaneous speed in km/h */
   speed_kmh?: Maybe<Scalars['Float']['output']>;
+  /** Road or terrain type */
+  surface_type?: Maybe<Scalars['String']['output']>;
   /** Ambient temperature in degrees C */
   temperature_c?: Maybe<Scalars['Float']['output']>;
   /** UTC timestamp of the data point */
@@ -308,16 +316,24 @@ export interface GarminTrackPoint {
   created_at?: Maybe<Scalars['String']['output']>;
   /** Cumulative distance from activity start in km */
   distance_from_start_km?: Maybe<Scalars['Float']['output']>;
+  /** Effort classification label */
+  effort_level?: Maybe<Scalars['String']['output']>;
   /** Heart rate in beats per minute */
   heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Heart-rate zone index (1-5) */
+  hr_zone?: Maybe<Scalars['Int']['output']>;
   /** Unique track point record identifier */
   id: Scalars['Int']['output'];
   /** GPS latitude in decimal degrees (WGS 84) */
   latitude: Scalars['Float']['output'];
   /** GPS longitude in decimal degrees (WGS 84) */
   longitude: Scalars['Float']['output'];
+  /** Respiration rate in breaths per minute */
+  respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Instantaneous speed in km/h */
   speed_kmh?: Maybe<Scalars['Float']['output']>;
+  /** Road or terrain type */
+  surface_type?: Maybe<Scalars['String']['output']>;
   /** Ambient temperature in degrees C */
   temperature_c?: Maybe<Scalars['Float']['output']>;
   /** UTC timestamp of the track point recording */

--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -89,12 +89,18 @@ export interface GarminActivity {
   __typename?: 'GarminActivity';
   /** Garmin Connect activity identifier */
   activity_id: Scalars['String']['output'];
+  /** Aerobic training effect score */
+  aerobic_training_effect?: Maybe<Scalars['Float']['output']>;
+  /** Anaerobic training effect score */
+  anaerobic_training_effect?: Maybe<Scalars['Float']['output']>;
   /** Average cadence in RPM */
   avg_cadence?: Maybe<Scalars['Int']['output']>;
   /** Average heart rate in beats per minute */
   avg_heart_rate?: Maybe<Scalars['Int']['output']>;
   /** Average pace in minutes per kilometre */
   avg_pace?: Maybe<Scalars['Float']['output']>;
+  /** Average respiration rate in breaths per minute */
+  avg_respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Average speed in km/h */
   avg_speed_kmh?: Maybe<Scalars['Float']['output']>;
   /** Average ambient temperature in degrees C */
@@ -111,22 +117,38 @@ export interface GarminActivity {
   duration_seconds?: Maybe<Scalars['Float']['output']>;
   /** Activity end time in UTC */
   end_time?: Maybe<Scalars['String']['output']>;
+  /** Exercise load score */
+  exercise_load?: Maybe<Scalars['Int']['output']>;
+  /** Whether this activity has usable heart-rate data in summary or track points */
+  hr_available: Scalars['Boolean']['output'];
   /** Maximum cadence in RPM */
   max_cadence?: Maybe<Scalars['Int']['output']>;
   /** Maximum heart rate in beats per minute */
   max_heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Maximum respiration rate in breaths per minute */
+  max_respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Maximum speed in km/h */
   max_speed_kmh?: Maybe<Scalars['Float']['output']>;
   /** Maximum ambient temperature in degrees C */
   max_temperature_c?: Maybe<Scalars['Int']['output']>;
+  /** Minimum heart rate in beats per minute */
+  min_heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Minimum respiration rate in breaths per minute */
+  min_respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Minimum ambient temperature in degrees C */
   min_temperature_c?: Maybe<Scalars['Int']['output']>;
+  /** Moderate intensity minutes */
+  moderate_intensity_minutes?: Maybe<Scalars['Int']['output']>;
+  /** Distance over paved surfaces in kilometres */
+  paved_distance_km?: Maybe<Scalars['Float']['output']>;
   /** Primary sport type (e.g. cycling, running) */
   sport: Scalars['String']['output'];
   /** Activity start time in UTC */
   start_time?: Maybe<Scalars['String']['output']>;
   /** Sub-sport classification (e.g. road, trail) */
   sub_sport?: Maybe<Scalars['String']['output']>;
+  /** Estimated sweat loss in millilitres */
+  sweat_loss_ml?: Maybe<Scalars['Int']['output']>;
   /** Total elevation gain in meters */
   total_ascent_m?: Maybe<Scalars['Float']['output']>;
   /** Total elevation loss in meters */
@@ -135,12 +157,18 @@ export interface GarminActivity {
   total_distance?: Maybe<Scalars['Float']['output']>;
   /** Total elapsed time in seconds (includes pauses) */
   total_elapsed_time?: Maybe<Scalars['Float']['output']>;
+  /** Total intensity minutes */
+  total_intensity_minutes?: Maybe<Scalars['Int']['output']>;
   /** Total timer time in seconds (active recording) */
   total_timer_time?: Maybe<Scalars['Float']['output']>;
   /** Number of GPS track points in this activity */
   track_point_count?: Maybe<Scalars['Int']['output']>;
+  /** Distance over unpaved surfaces in kilometres */
+  unpaved_distance_km?: Maybe<Scalars['Float']['output']>;
   /** UTC timestamp when the FIT file was uploaded */
   uploaded_at?: Maybe<Scalars['String']['output']>;
+  /** Vigorous intensity minutes */
+  vigorous_intensity_minutes?: Maybe<Scalars['Int']['output']>;
 }
 
 /** Full reverse-geocoded address attached to a Garmin activity waypoint. */

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -92,12 +92,18 @@ export type GarminActivity = {
   __typename?: 'GarminActivity';
   /** Garmin Connect activity identifier */
   activity_id: Scalars['String']['output'];
+  /** Aerobic training effect score */
+  aerobic_training_effect?: Maybe<Scalars['Float']['output']>;
+  /** Anaerobic training effect score */
+  anaerobic_training_effect?: Maybe<Scalars['Float']['output']>;
   /** Average cadence in RPM */
   avg_cadence?: Maybe<Scalars['Int']['output']>;
   /** Average heart rate in beats per minute */
   avg_heart_rate?: Maybe<Scalars['Int']['output']>;
   /** Average pace in minutes per kilometre */
   avg_pace?: Maybe<Scalars['Float']['output']>;
+  /** Average respiration rate in breaths per minute */
+  avg_respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Average speed in km/h */
   avg_speed_kmh?: Maybe<Scalars['Float']['output']>;
   /** Average ambient temperature in degrees C */
@@ -114,22 +120,38 @@ export type GarminActivity = {
   duration_seconds?: Maybe<Scalars['Float']['output']>;
   /** Activity end time in UTC */
   end_time?: Maybe<Scalars['String']['output']>;
+  /** Exercise load score */
+  exercise_load?: Maybe<Scalars['Int']['output']>;
+  /** Whether this activity has usable heart-rate data in summary or track points */
+  hr_available: Scalars['Boolean']['output'];
   /** Maximum cadence in RPM */
   max_cadence?: Maybe<Scalars['Int']['output']>;
   /** Maximum heart rate in beats per minute */
   max_heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Maximum respiration rate in breaths per minute */
+  max_respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Maximum speed in km/h */
   max_speed_kmh?: Maybe<Scalars['Float']['output']>;
   /** Maximum ambient temperature in degrees C */
   max_temperature_c?: Maybe<Scalars['Int']['output']>;
+  /** Minimum heart rate in beats per minute */
+  min_heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Minimum respiration rate in breaths per minute */
+  min_respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Minimum ambient temperature in degrees C */
   min_temperature_c?: Maybe<Scalars['Int']['output']>;
+  /** Moderate intensity minutes */
+  moderate_intensity_minutes?: Maybe<Scalars['Int']['output']>;
+  /** Distance over paved surfaces in kilometres */
+  paved_distance_km?: Maybe<Scalars['Float']['output']>;
   /** Primary sport type (e.g. cycling, running) */
   sport: Scalars['String']['output'];
   /** Activity start time in UTC */
   start_time?: Maybe<Scalars['String']['output']>;
   /** Sub-sport classification (e.g. road, trail) */
   sub_sport?: Maybe<Scalars['String']['output']>;
+  /** Estimated sweat loss in millilitres */
+  sweat_loss_ml?: Maybe<Scalars['Int']['output']>;
   /** Total elevation gain in meters */
   total_ascent_m?: Maybe<Scalars['Float']['output']>;
   /** Total elevation loss in meters */
@@ -138,12 +160,18 @@ export type GarminActivity = {
   total_distance?: Maybe<Scalars['Float']['output']>;
   /** Total elapsed time in seconds (includes pauses) */
   total_elapsed_time?: Maybe<Scalars['Float']['output']>;
+  /** Total intensity minutes */
+  total_intensity_minutes?: Maybe<Scalars['Int']['output']>;
   /** Total timer time in seconds (active recording) */
   total_timer_time?: Maybe<Scalars['Float']['output']>;
   /** Number of GPS track points in this activity */
   track_point_count?: Maybe<Scalars['Int']['output']>;
+  /** Distance over unpaved surfaces in kilometres */
+  unpaved_distance_km?: Maybe<Scalars['Float']['output']>;
   /** UTC timestamp when the FIT file was uploaded */
   uploaded_at?: Maybe<Scalars['String']['output']>;
+  /** Vigorous intensity minutes */
+  vigorous_intensity_minutes?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Full reverse-geocoded address attached to a Garmin activity waypoint. */
@@ -1069,9 +1097,12 @@ export type DistanceResultResolvers<ContextType = GatewayContext, ParentType ext
 
 export type GarminActivityResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminActivity'] = ResolversParentTypes['GarminActivity']> = ResolversObject<{
   activity_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  aerobic_training_effect?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  anaerobic_training_effect?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   avg_cadence?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   avg_heart_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   avg_pace?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  avg_respiration_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   avg_speed_kmh?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   avg_temperature_c?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   calories?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -1080,21 +1111,32 @@ export type GarminActivityResolvers<ContextType = GatewayContext, ParentType ext
   distance_km?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   duration_seconds?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   end_time?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  exercise_load?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  hr_available?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   max_cadence?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   max_heart_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  max_respiration_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   max_speed_kmh?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   max_temperature_c?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  min_heart_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  min_respiration_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   min_temperature_c?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  moderate_intensity_minutes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  paved_distance_km?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   sport?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   start_time?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   sub_sport?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  sweat_loss_ml?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   total_ascent_m?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_descent_m?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_distance?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_elapsed_time?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  total_intensity_minutes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   total_timer_time?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   track_point_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  unpaved_distance_km?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   uploaded_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  vigorous_intensity_minutes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
 }>;
 
 export type GarminActivityAddressResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminActivityAddress'] = ResolversParentTypes['GarminActivityAddress']> = ResolversObject<{

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -252,14 +252,22 @@ export type GarminChartPoint = {
   cadence?: Maybe<Scalars['Int']['output']>;
   /** Cumulative distance from activity start in km */
   distance_from_start_km?: Maybe<Scalars['Float']['output']>;
+  /** Effort classification label */
+  effort_level?: Maybe<Scalars['String']['output']>;
   /** Heart rate in beats per minute */
   heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Heart-rate zone index (1-5) */
+  hr_zone?: Maybe<Scalars['Int']['output']>;
   /** GPS latitude in decimal degrees (WGS 84) */
   latitude: Scalars['Float']['output'];
   /** GPS longitude in decimal degrees (WGS 84) */
   longitude: Scalars['Float']['output'];
+  /** Respiration rate in breaths per minute */
+  respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Instantaneous speed in km/h */
   speed_kmh?: Maybe<Scalars['Float']['output']>;
+  /** Road or terrain type */
+  surface_type?: Maybe<Scalars['String']['output']>;
   /** Ambient temperature in degrees C */
   temperature_c?: Maybe<Scalars['Float']['output']>;
   /** UTC timestamp of the data point */
@@ -311,16 +319,24 @@ export type GarminTrackPoint = {
   created_at?: Maybe<Scalars['String']['output']>;
   /** Cumulative distance from activity start in km */
   distance_from_start_km?: Maybe<Scalars['Float']['output']>;
+  /** Effort classification label */
+  effort_level?: Maybe<Scalars['String']['output']>;
   /** Heart rate in beats per minute */
   heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Heart-rate zone index (1-5) */
+  hr_zone?: Maybe<Scalars['Int']['output']>;
   /** Unique track point record identifier */
   id: Scalars['Int']['output'];
   /** GPS latitude in decimal degrees (WGS 84) */
   latitude: Scalars['Float']['output'];
   /** GPS longitude in decimal degrees (WGS 84) */
   longitude: Scalars['Float']['output'];
+  /** Respiration rate in breaths per minute */
+  respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Instantaneous speed in km/h */
   speed_kmh?: Maybe<Scalars['Float']['output']>;
+  /** Road or terrain type */
+  surface_type?: Maybe<Scalars['String']['output']>;
   /** Ambient temperature in degrees C */
   temperature_c?: Maybe<Scalars['Float']['output']>;
   /** UTC timestamp of the track point recording */
@@ -1179,10 +1195,14 @@ export type GarminChartPointResolvers<ContextType = GatewayContext, ParentType e
   altitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   cadence?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   distance_from_start_km?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  effort_level?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   heart_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  hr_zone?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   latitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   longitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  respiration_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   speed_kmh?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  surface_type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   temperature_c?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   timestamp?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
 }>;
@@ -1210,11 +1230,15 @@ export type GarminTrackPointResolvers<ContextType = GatewayContext, ParentType e
   cadence?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   created_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   distance_from_start_km?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  effort_level?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   heart_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  hr_zone?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   latitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   longitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  respiration_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   speed_kmh?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  surface_type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   temperature_c?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   timestamp?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
 }>;

--- a/src/resolvers/garmin.ts
+++ b/src/resolvers/garmin.ts
@@ -20,11 +20,36 @@ export const garminResolvers: {
     },
 
     garminActivities: async (_parent, args, { dataSources }) => {
-      return dataSources.otelAPI.getGarminActivities(args);
+      const connection = await dataSources.otelAPI.getGarminActivities(args);
+      return {
+        ...connection,
+        items: connection.items.map((item) => {
+          const source = item as Record<string, unknown>;
+          const avgHr = source['avg_heart_rate'];
+          const maxHr = source['max_heart_rate'];
+          const hrAvailable = source['hr_available'];
+
+          return {
+            ...item,
+            hr_available:
+              typeof hrAvailable === 'boolean' ? hrAvailable : avgHr != null || maxHr != null,
+          };
+        }),
+      };
     },
 
     garminActivity: async (_parent, args, { dataSources }) => {
-      return dataSources.otelAPI.getGarminActivity(args.activity_id);
+      const activity = await dataSources.otelAPI.getGarminActivity(args.activity_id);
+      const source = activity as Record<string, unknown>;
+      const avgHr = source['avg_heart_rate'];
+      const maxHr = source['max_heart_rate'];
+      const hrAvailable = source['hr_available'];
+
+      return {
+        ...activity,
+        hr_available:
+          typeof hrAvailable === 'boolean' ? hrAvailable : avgHr != null || maxHr != null,
+      };
     },
 
     garminTrackPoints: async (_parent, args, { dataSources }) => {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -675,6 +675,14 @@ type GarminTrackPoint {
   """
   heart_rate: Int
   """
+  Heart-rate zone index (1-5)
+  """
+  hr_zone: Int
+  """
+  Respiration rate in breaths per minute
+  """
+  respiration_rate: Int
+  """
   Pedal/step cadence in RPM
   """
   cadence: Int
@@ -682,6 +690,14 @@ type GarminTrackPoint {
   Ambient temperature in degrees C
   """
   temperature_c: Float
+  """
+  Road or terrain type
+  """
+  surface_type: String
+  """
+  Effort classification label
+  """
+  effort_level: String
   """
   UTC timestamp when the record was inserted
   """
@@ -881,6 +897,14 @@ type GarminChartPoint {
   """
   heart_rate: Int
   """
+  Heart-rate zone index (1-5)
+  """
+  hr_zone: Int
+  """
+  Respiration rate in breaths per minute
+  """
+  respiration_rate: Int
+  """
   Pedal/step cadence in RPM
   """
   cadence: Int
@@ -888,6 +912,14 @@ type GarminChartPoint {
   Ambient temperature in degrees C
   """
   temperature_c: Float
+  """
+  Road or terrain type
+  """
+  surface_type: String
+  """
+  Effort classification label
+  """
+  effort_level: String
   """
   GPS latitude in decimal degrees (WGS 84)
   """

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -469,6 +469,62 @@ type GarminActivity {
   """
   max_heart_rate: Int
   """
+  Whether this activity has usable heart-rate data in summary or track points
+  """
+  hr_available: Boolean!
+  """
+  Minimum heart rate in beats per minute
+  """
+  min_heart_rate: Int
+  """
+  Aerobic training effect score
+  """
+  aerobic_training_effect: Float
+  """
+  Anaerobic training effect score
+  """
+  anaerobic_training_effect: Float
+  """
+  Exercise load score
+  """
+  exercise_load: Int
+  """
+  Average respiration rate in breaths per minute
+  """
+  avg_respiration_rate: Int
+  """
+  Minimum respiration rate in breaths per minute
+  """
+  min_respiration_rate: Int
+  """
+  Maximum respiration rate in breaths per minute
+  """
+  max_respiration_rate: Int
+  """
+  Estimated sweat loss in millilitres
+  """
+  sweat_loss_ml: Int
+  """
+  Moderate intensity minutes
+  """
+  moderate_intensity_minutes: Int
+  """
+  Vigorous intensity minutes
+  """
+  vigorous_intensity_minutes: Int
+  """
+  Total intensity minutes
+  """
+  total_intensity_minutes: Int
+  """
+  Distance over paved surfaces in kilometres
+  """
+  paved_distance_km: Float
+  """
+  Distance over unpaved surfaces in kilometres
+  """
+  unpaved_distance_km: Float
+  """
   Average cadence in RPM
   """
   avg_cadence: Int


### PR DESCRIPTION
## Summary

Adds Garmin activity-detail support to the GraphQL gateway. This is "slice 1" of
the activity-detail work, covering heart-rate availability plus a set of
per-point metric fields that pass through from `otel-data-api`.

## Changes

- **HR availability** — expose heart-rate availability in the Garmin resolver
  (`src/resolvers/garmin.ts`) so the UI can decide whether to render HR-derived
  views.
- **Per-point metric fields** — add four nullable fields to both
  `GarminTrackPoint` and `GarminChartPoint`:
  - `hr_zone: Int` — heart-rate zone index (1-5)
  - `respiration_rate: Int` — breaths per minute
  - `surface_type: String` — road/terrain type
  - `effort_level: String` — effort classification label
- Regenerated GraphQL types (`src/__generated__/resolvers-types.ts`,
  `packages/graphql-types/index.d.ts`) and added the relevant cspell words.

## Backend support

All four fields are already supported on `otel-data-api` **master** — present in
the Pydantic models (`app/models/garmin.py`) and selected by the SQL queries in
`app/routers/garmin.py`. The gateway is a passthrough BFF, so these fields are
resolved via default resolvers from the REST JSON; no extra datasource wiring is
required. Fields are nullable and degrade gracefully when absent.

## Validation

Run locally on the branch HEAD:

- `npm run type-check` — pass
- `npm run lint:all` — pass (eslint, markdownlint, shellcheck, cspell)
- `npm run build` (incl. codegen) — pass
- `npm test` — 51/51 tests pass, coverage 89.3% stmts

## Notes

- No breaking changes; all additions are optional/nullable.
- Downstream `otel-data-ui` can begin querying these fields once this merges and
  the gateway image is deployed.