### PR TITLE
ci: auto-merge otel-data-types dependency PRs on green checks

### DIFF
--- a/.github/workflows/update-types.yml
+++ b/.github/workflows/update-types.yml
@@ -102,6 +102,7 @@ jobs:
 
       - name: Enable auto-merge
         if: steps.cpr.outputs.pull-request-number
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITOPS_PAT }}
         run: |

--- a/.github/workflows/update-types.yml
+++ b/.github/workflows/update-types.yml
@@ -64,6 +64,7 @@ jobs:
           echo "Updated @stuartshay/otel-data-types to ${VERSION}"
 
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITOPS_PAT }}
@@ -98,6 +99,16 @@ jobs:
             automated
             types-update
             otel-data-types
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITOPS_PAT }}
+        run: |
+          gh pr merge --auto --squash \
+            --repo "${{ github.repository }}" \
+            "${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Auto-merge enabled for PR #${{ steps.cpr.outputs.pull-request-number }} (merges once required checks pass)"
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

Enables GitHub native **auto-merge (squash)** on the automated `@stuartshay/otel-data-types` version-bump PRs created by `update-types.yml`.

## Why
These PRs are mechanical, narrow (only `package.json` + `package-lock.json`), and the type contract is already validated upstream when the API publishes. The only remaining friction is a manual merge click.

## How it stays safe
- Uses `gh pr merge --auto --squash` — GitHub merges **only after required status checks pass** (`Build and Push`, `Build Check`, `ESLint and TypeScript Check`).
- A breaking type change keeps CI red → PR does **not** merge.
- The existing `auto-approve.yml` still satisfies the approval requirement.
- Repo setting `allow_auto_merge` is already enabled.

## Scope
Only affects bot-generated types-update PRs; all other PRs remain fully manual.