### PR TITLE
feat(garmin): expose recording device metadata on GarminActivity

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -109,6 +109,8 @@ export interface GarminActivity {
   calories?: Maybe<Scalars['Int']['output']>;
   /** UTC timestamp when the record was inserted */
   created_at?: Maybe<Scalars['String']['output']>;
+  /** Recording device metadata (manufacturer, model, firmware) */
+  device?: Maybe<GarminDevice>;
   /** Device manufacturer (e.g. garmin) */
   device_manufacturer?: Maybe<Scalars['String']['output']>;
   /** Total distance in kilometres */
@@ -276,6 +278,21 @@ export interface GarminDateRange {
   max_date: Scalars['DateTime']['output'];
   /** Earliest Garmin activity timestamp (ISO 8601) */
   min_date: Scalars['DateTime']['output'];
+}
+
+/** Recording device metadata captured from a Garmin activity's FIT file. */
+export interface GarminDevice {
+  __typename?: 'GarminDevice';
+  /** Recording device serial number */
+  device_id?: Maybe<Scalars['Float']['output']>;
+  /** Raw Garmin product enum id from the FIT file (e.g. 4061) */
+  garmin_product?: Maybe<Scalars['Int']['output']>;
+  /** Device manufacturer (e.g. garmin) */
+  manufacturer?: Maybe<Scalars['String']['output']>;
+  /** Friendly device model name (e.g. Edge 540 Solar) */
+  model?: Maybe<Scalars['String']['output']>;
+  /** Device firmware/software version (e.g. 31.30) */
+  software_version?: Maybe<Scalars['String']['output']>;
 }
 
 /** Result payload returned when triggering an on-demand Garmin sync. */

--- a/packages/graphql-types/schema.graphql
+++ b/packages/graphql-types/schema.graphql
@@ -285,6 +285,62 @@ type GeocodingStatus {
   Percentage of locations with a geocoded address
   """
   coverage_percent: Float!
+  """
+  Per-source breakdown of geocoding coverage (owntracks, garmin)
+  """
+  by_source: GeocodingStatusBySource!
+}
+
+"""
+Coverage statistics for a single geocoding source (owntracks or garmin).
+"""
+type GeocodingSourceStatus {
+  """
+  Number of successfully geocoded records for this source
+  """
+  success: Int!
+  """
+  Number of records awaiting geocoding for this source
+  """
+  pending: Int!
+  """
+  Number of records outside Pelias coverage area
+  """
+  no_coverage: Int!
+  """
+  Number of records that failed geocoding
+  """
+  errors: Int!
+  """
+  Total number of geocoded_addresses rows for this source
+  """
+  total: Int!
+}
+
+"""
+Per-source breakdown of geocoding coverage.
+"""
+type GeocodingStatusBySource {
+  """
+  Coverage stats for OwnTracks rows
+  """
+  owntracks: GeocodingSourceStatus!
+  """
+  Coverage stats for Garmin rows
+  """
+  garmin: GeocodingSourceStatus!
+  """
+  Total number of Garmin activities (denominator for activity-level coverage)
+  """
+  garmin_activities_total: Int!
+  """
+  Number of Garmin activities that have at least one address row
+  """
+  garmin_activities_geocoded: Int!
+  """
+  Percentage of Garmin activities with at least one geocoded address
+  """
+  garmin_coverage_percent: Float!
 }
 
 """
@@ -373,6 +429,32 @@ type LocationDateRange {
 # Garmin
 # -------------------------------------------------------
 """
+Recording device metadata captured from a Garmin activity's FIT file.
+"""
+type GarminDevice {
+  """
+  Recording device serial number
+  """
+  device_id: Float
+  """
+  Device manufacturer (e.g. garmin)
+  """
+  manufacturer: String
+  """
+  Raw Garmin product enum id from the FIT file (e.g. 4061)
+  """
+  garmin_product: Int
+  """
+  Friendly device model name (e.g. Edge 540 Solar)
+  """
+  model: String
+  """
+  Device firmware/software version (e.g. 31.30)
+  """
+  software_version: String
+}
+
+"""
 Summary of a Garmin Connect activity parsed from a FIT file.
 """
 type GarminActivity {
@@ -413,6 +495,62 @@ type GarminActivity {
   """
   max_heart_rate: Int
   """
+  Whether this activity has usable heart-rate data in summary or track points
+  """
+  hr_available: Boolean!
+  """
+  Minimum heart rate in beats per minute
+  """
+  min_heart_rate: Int
+  """
+  Aerobic training effect score
+  """
+  aerobic_training_effect: Float
+  """
+  Anaerobic training effect score
+  """
+  anaerobic_training_effect: Float
+  """
+  Exercise load score
+  """
+  exercise_load: Int
+  """
+  Average respiration rate in breaths per minute
+  """
+  avg_respiration_rate: Int
+  """
+  Minimum respiration rate in breaths per minute
+  """
+  min_respiration_rate: Int
+  """
+  Maximum respiration rate in breaths per minute
+  """
+  max_respiration_rate: Int
+  """
+  Estimated sweat loss in millilitres
+  """
+  sweat_loss_ml: Int
+  """
+  Moderate intensity minutes
+  """
+  moderate_intensity_minutes: Int
+  """
+  Vigorous intensity minutes
+  """
+  vigorous_intensity_minutes: Int
+  """
+  Total intensity minutes
+  """
+  total_intensity_minutes: Int
+  """
+  Distance over paved surfaces in kilometres
+  """
+  paved_distance_km: Float
+  """
+  Distance over unpaved surfaces in kilometres
+  """
+  unpaved_distance_km: Float
+  """
   Average cadence in RPM
   """
   avg_cadence: Int
@@ -420,6 +558,10 @@ type GarminActivity {
   Maximum cadence in RPM
   """
   max_cadence: Int
+  """
+  Total activity strokes
+  """
+  total_strokes: Int
   """
   Total calories burned
   """
@@ -452,6 +594,10 @@ type GarminActivity {
   Device manufacturer (e.g. garmin)
   """
   device_manufacturer: String
+  """
+  Recording device metadata (manufacturer, model, firmware)
+  """
+  device: GarminDevice
   """
   Average ambient temperature in degrees C
   """
@@ -563,6 +709,14 @@ type GarminTrackPoint {
   """
   heart_rate: Int
   """
+  Heart-rate zone index (1-5)
+  """
+  hr_zone: Int
+  """
+  Respiration rate in breaths per minute
+  """
+  respiration_rate: Int
+  """
   Pedal/step cadence in RPM
   """
   cadence: Int
@@ -571,9 +725,149 @@ type GarminTrackPoint {
   """
   temperature_c: Float
   """
+  Road or terrain type
+  """
+  surface_type: String
+  """
+  Effort classification label
+  """
+  effort_level: String
+  """
   UTC timestamp when the record was inserted
   """
   created_at: String
+  """
+  Compact reverse-geocoded address summary, when geocoded
+  """
+  address: GeocodedAddressSummary
+}
+
+"""
+Compact reverse-geocoded address summary embedded in track-point payloads.
+"""
+type GeocodedAddressSummary {
+  """
+  Full formatted address label from Pelias
+  """
+  display_address: String
+  """
+  Street name
+  """
+  street: String
+  """
+  House or building number
+  """
+  housenumber: String
+  """
+  Neighbourhood name
+  """
+  neighbourhood: String
+  """
+  City or town
+  """
+  locality: String
+  """
+  State or province
+  """
+  region: String
+  """
+  Country name
+  """
+  country: String
+  """
+  Postal or ZIP code
+  """
+  postalcode: String
+  """
+  Pelias confidence score (0-1)
+  """
+  confidence: Float
+  """
+  Role of this waypoint within a Garmin activity (start, end, waypoint). Null for OwnTracks records.
+  """
+  waypoint_kind: String
+  """
+  Geocoding status: success, no_coverage, error, pending
+  """
+  status: String!
+  """
+  UTC timestamp when geocoding was performed
+  """
+  geocoded_at: String
+}
+
+"""
+Full reverse-geocoded address attached to a Garmin activity waypoint.
+"""
+type GarminActivityAddress {
+  """
+  garmin_track_points.id this address was geocoded from
+  """
+  track_point_id: Int!
+  """
+  Parent Garmin activity identifier
+  """
+  activity_id: String!
+  """
+  Role of this waypoint within the activity: start, end, or waypoint
+  """
+  waypoint_kind: String!
+  """
+  UTC timestamp of the track point this address was derived from
+  """
+  timestamp: DateTime!
+  """
+  GPS latitude in decimal degrees (WGS 84)
+  """
+  latitude: Float!
+  """
+  GPS longitude in decimal degrees (WGS 84)
+  """
+  longitude: Float!
+  """
+  Full formatted address label from Pelias
+  """
+  display_address: String
+  """
+  Street name
+  """
+  street: String
+  """
+  House or building number
+  """
+  housenumber: String
+  """
+  Neighbourhood name
+  """
+  neighbourhood: String
+  """
+  City or town
+  """
+  locality: String
+  """
+  State or province
+  """
+  region: String
+  """
+  Country name
+  """
+  country: String
+  """
+  Postal or ZIP code
+  """
+  postalcode: String
+  """
+  Pelias confidence score (0-1)
+  """
+  confidence: Float
+  """
+  Geocoding status: success, no_coverage, error, pending
+  """
+  status: String!
+  """
+  UTC timestamp when geocoding was performed
+  """
+  geocoded_at: String
 }
 
 """
@@ -636,6 +930,14 @@ type GarminChartPoint {
   Heart rate in beats per minute
   """
   heart_rate: Int
+  """
+  Heart-rate zone index (1-5)
+  """
+  hr_zone: Int
+  """
+  Respiration rate in breaths per minute
+  """
+  respiration_rate: Int
   """
   Pedal/step cadence in RPM
   """
@@ -1199,6 +1501,16 @@ type Query {
     """
     activity_id: String!
   ): [GarminChartPoint!]!
+
+  """
+  Retrieve all reverse-geocoded addresses for a Garmin activity (start, mid-route waypoints, and end).
+  """
+  garminActivityAddresses(
+    """
+    Garmin Connect activity identifier
+    """
+    activity_id: String!
+  ): [GarminActivityAddress!]!
 
   """
   Aggregate Garmin activity totals grouped by week, month, or year.

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -112,6 +112,8 @@ export type GarminActivity = {
   calories?: Maybe<Scalars['Int']['output']>;
   /** UTC timestamp when the record was inserted */
   created_at?: Maybe<Scalars['String']['output']>;
+  /** Recording device metadata (manufacturer, model, firmware) */
+  device?: Maybe<GarminDevice>;
   /** Device manufacturer (e.g. garmin) */
   device_manufacturer?: Maybe<Scalars['String']['output']>;
   /** Total distance in kilometres */
@@ -279,6 +281,21 @@ export type GarminDateRange = {
   max_date: Scalars['DateTime']['output'];
   /** Earliest Garmin activity timestamp (ISO 8601) */
   min_date: Scalars['DateTime']['output'];
+};
+
+/** Recording device metadata captured from a Garmin activity's FIT file. */
+export type GarminDevice = {
+  __typename?: 'GarminDevice';
+  /** Recording device serial number */
+  device_id?: Maybe<Scalars['Float']['output']>;
+  /** Raw Garmin product enum id from the FIT file (e.g. 4061) */
+  garmin_product?: Maybe<Scalars['Int']['output']>;
+  /** Device manufacturer (e.g. garmin) */
+  manufacturer?: Maybe<Scalars['String']['output']>;
+  /** Friendly device model name (e.g. Edge 540 Solar) */
+  model?: Maybe<Scalars['String']['output']>;
+  /** Device firmware/software version (e.g. 31.30) */
+  software_version?: Maybe<Scalars['String']['output']>;
 };
 
 /** Result payload returned when triggering an on-demand Garmin sync. */
@@ -989,6 +1006,7 @@ export type ResolversTypes = ResolversObject<{
   GarminActivityTotal: ResolverTypeWrapper<GarminActivityTotal>;
   GarminChartPoint: ResolverTypeWrapper<GarminChartPoint>;
   GarminDateRange: ResolverTypeWrapper<GarminDateRange>;
+  GarminDevice: ResolverTypeWrapper<GarminDevice>;
   GarminSyncTriggerResult: ResolverTypeWrapper<GarminSyncTriggerResult>;
   GarminTrackPoint: ResolverTypeWrapper<GarminTrackPoint>;
   GarminTrackPointConnection: ResolverTypeWrapper<GarminTrackPointConnection>;
@@ -1036,6 +1054,7 @@ export type ResolversParentTypes = ResolversObject<{
   GarminActivityTotal: GarminActivityTotal;
   GarminChartPoint: GarminChartPoint;
   GarminDateRange: GarminDateRange;
+  GarminDevice: GarminDevice;
   GarminSyncTriggerResult: GarminSyncTriggerResult;
   GarminTrackPoint: GarminTrackPoint;
   GarminTrackPointConnection: GarminTrackPointConnection;
@@ -1121,6 +1140,7 @@ export type GarminActivityResolvers<ContextType = GatewayContext, ParentType ext
   avg_temperature_c?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   calories?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   created_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  device?: Resolver<Maybe<ResolversTypes['GarminDevice']>, ParentType, ContextType>;
   device_manufacturer?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   distance_km?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   duration_seconds?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
@@ -1207,6 +1227,14 @@ export type GarminChartPointResolvers<ContextType = GatewayContext, ParentType e
 export type GarminDateRangeResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminDateRange'] = ResolversParentTypes['GarminDateRange']> = ResolversObject<{
   max_date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   min_date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+}>;
+
+export type GarminDeviceResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminDevice'] = ResolversParentTypes['GarminDevice']> = ResolversObject<{
+  device_id?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  garmin_product?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  manufacturer?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  model?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  software_version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type GarminSyncTriggerResultResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminSyncTriggerResult'] = ResolversParentTypes['GarminSyncTriggerResult']> = ResolversObject<{
@@ -1482,6 +1510,7 @@ export type Resolvers<ContextType = GatewayContext> = ResolversObject<{
   GarminActivityTotal?: GarminActivityTotalResolvers<ContextType>;
   GarminChartPoint?: GarminChartPointResolvers<ContextType>;
   GarminDateRange?: GarminDateRangeResolvers<ContextType>;
+  GarminDevice?: GarminDeviceResolvers<ContextType>;
   GarminSyncTriggerResult?: GarminSyncTriggerResultResolvers<ContextType>;
   GarminTrackPoint?: GarminTrackPointResolvers<ContextType>;
   GarminTrackPointConnection?: GarminTrackPointConnectionResolvers<ContextType>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -429,6 +429,32 @@ type LocationDateRange {
 # Garmin
 # -------------------------------------------------------
 """
+Recording device metadata captured from a Garmin activity's FIT file.
+"""
+type GarminDevice {
+  """
+  Recording device serial number
+  """
+  device_id: Float
+  """
+  Device manufacturer (e.g. garmin)
+  """
+  manufacturer: String
+  """
+  Raw Garmin product enum id from the FIT file (e.g. 4061)
+  """
+  garmin_product: Int
+  """
+  Friendly device model name (e.g. Edge 540 Solar)
+  """
+  model: String
+  """
+  Device firmware/software version (e.g. 31.30)
+  """
+  software_version: String
+}
+
+"""
 Summary of a Garmin Connect activity parsed from a FIT file.
 """
 type GarminActivity {
@@ -568,6 +594,10 @@ type GarminActivity {
   Device manufacturer (e.g. garmin)
   """
   device_manufacturer: String
+  """
+  Recording device metadata (manufacturer, model, firmware)
+  """
+  device: GarminDevice
   """
   Average ambient temperature in degrees C
   """

--- a/tests/resolvers/resolvers.test.ts
+++ b/tests/resolvers/resolvers.test.ts
@@ -175,6 +175,41 @@ describe('garmin resolvers', () => {
     expect(ctx.dataSources.otelAPI.getGarminChartData).toHaveBeenCalledWith('abc');
   });
 
+  it('passes device metadata through garminActivity', async () => {
+    const device = {
+      device_id: 3444454776,
+      manufacturer: 'garmin',
+      garmin_product: 4061,
+      model: 'Edge 540 Solar',
+      software_version: '31.30',
+    };
+    const ctx = contextWith({
+      getGarminActivity: mockAsync({ activity_id: 'abc', avg_heart_rate: 120, device }),
+    });
+
+    const activity = await runResolver<{ activity_id: string }, { device?: typeof device }>(
+      garminResolvers.Query.garminActivity,
+      { activity_id: 'abc' },
+      ctx,
+    );
+
+    expect(activity.device).toEqual(device);
+  });
+
+  it('returns null device when activity has no recording device', async () => {
+    const ctx = contextWith({
+      getGarminActivity: mockAsync({ activity_id: 'abc', avg_heart_rate: 120, device: null }),
+    });
+
+    const activity = await runResolver<{ activity_id: string }, { device?: unknown }>(
+      garminResolvers.Query.garminActivity,
+      { activity_id: 'abc' },
+      ctx,
+    );
+
+    expect(activity.device).toBeNull();
+  });
+
   it('passes filter args to garminActivityTotals', async () => {
     const args = {
       period: 'week',

--- a/tests/schema/typeDefs.test.ts
+++ b/tests/schema/typeDefs.test.ts
@@ -98,4 +98,51 @@ describe('typeDefs', () => {
       },
     });
   });
+
+  it('exposes recording device metadata on a Garmin activity', async () => {
+    const schema = buildSchema(typeDefs);
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          garminActivity(activity_id: "activity-1") {
+            activity_id
+            device {
+              device_id
+              manufacturer
+              garmin_product
+              model
+              software_version
+            }
+          }
+        }
+      `,
+      rootValue: {
+        garminActivity: () => ({
+          activity_id: 'activity-1',
+          device: {
+            device_id: 3444454776,
+            manufacturer: 'garmin',
+            garmin_product: 4061,
+            model: 'Edge 540 Solar',
+            software_version: '31.30',
+          },
+        }),
+      },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      garminActivity: {
+        activity_id: 'activity-1',
+        device: {
+          device_id: 3444454776,
+          manufacturer: 'garmin',
+          garmin_product: 4061,
+          model: 'Edge 540 Solar',
+          software_version: '31.30',
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Phase 4 of the Garmin per-activity device metadata feature. Surfaces the recording device (manufacturer, model, firmware, etc.) through the GraphQL API so the UI can display it on the activity detail page.

## Changes
- **schema** (`src/schema/schema.graphql`): new `GarminDevice` type and a `device: GarminDevice` field on `GarminActivity`.
- **passthrough**: the REST `device` object from otel-data-api (`@stuartshay/otel-data-types@1.0.473`) flows through the existing `garminActivity` resolver spread — no resolver/datasource change needed.
- **codegen**: regenerated `src/__generated__/resolvers-types.ts` and the publishable `packages/graphql-types/` (`index.d.ts` + `schema.graphql`).
- **tests**: resolver passthrough (device present + null) and a schema-level `garminActivity { device { ... } }` query test.

## Notes
- `device_id` is typed `Float` (not `Int`) because Garmin serial numbers (e.g. `3444454776`) exceed GraphQL's 32-bit `Int` range.

## Validation
- `npm run type-check` ✅
- `npm test` → 60 passed ✅
- `npm run build` ✅
- `npm run lint:all` ✅

## Field shape
```graphql
type GarminDevice {
  device_id: Float
  manufacturer: String
  garmin_product: Int
  model: String
  software_version: String
}
```

Once merged + released, `@stuartshay/otel-graphql-types` publishes with `GarminDevice`, auto-creating the otel-data-ui dependency PR for Phase 5.

Refs: Garmin device metadata feature (DB → agent → API → **gateway** → UI).

## Note on the `packages/graphql-types/schema.graphql` diff
The published SDL diff is large (+312 lines) because that file is a build artifact that had drifted from source; `build:types-package` resyncs it wholesale. **This adds no new downstream surface** — every backlog type was already in master's published `index.d.ts` (which only gained +17 lines here for `GarminDevice`), and `publish-types.yml` already regenerates the SDL fresh on every release. Tracked as follow-up #141 (stop committing the generated SDL).
