### PR TITLE
[codex] Add Garmin device counts query

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -295,6 +295,15 @@ export interface GarminDevice {
   software_version?: Maybe<Scalars['String']['output']>;
 }
 
+/** Garmin activity count grouped by recording device model. */
+export interface GarminDeviceCount {
+  __typename?: 'GarminDeviceCount';
+  /** Number of activities for this device label. */
+  activity_count: Scalars['Int']['output'];
+  /** Device model label, or Manual when an activity has no recording device. */
+  label: Scalars['String']['output'];
+}
+
 /** Result payload returned when triggering an on-demand Garmin sync. */
 export interface GarminSyncTriggerResult {
   __typename?: 'GarminSyncTriggerResult';
@@ -668,6 +677,8 @@ export interface Query {
   garminChartData: Array<GarminChartPoint>;
   /** Get the earliest and latest Garmin activity timestamps. */
   garminDateRange: GarminDateRange;
+  /** List Garmin recording device labels with activity counts. */
+  garminDeviceCounts: Array<GarminDeviceCount>;
   /** List all distinct sport types with activity counts. */
   garminSports: Array<SportInfo>;
   /** Retrieve paginated GPS track points for a Garmin activity. */

--- a/packages/graphql-types/schema.graphql
+++ b/packages/graphql-types/schema.graphql
@@ -907,6 +907,20 @@ type SportInfo {
 }
 
 """
+Garmin activity count grouped by recording device model.
+"""
+type GarminDeviceCount {
+  """
+  Device model label, or Manual when an activity has no recording device.
+  """
+  label: String!
+  """
+  Number of activities for this device label.
+  """
+  activity_count: Int!
+}
+
+"""
 Lightweight track point optimised for time-series chart rendering.
 """
 type GarminChartPoint {
@@ -1491,6 +1505,11 @@ type Query {
   List all distinct sport types with activity counts.
   """
   garminSports: [SportInfo!]!
+
+  """
+  List Garmin recording device labels with activity counts.
+  """
+  garminDeviceCounts: [GarminDeviceCount!]!
 
   """
   Retrieve chart-optimised track points for a Garmin activity.

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -298,6 +298,15 @@ export type GarminDevice = {
   software_version?: Maybe<Scalars['String']['output']>;
 };
 
+/** Garmin activity count grouped by recording device model. */
+export type GarminDeviceCount = {
+  __typename?: 'GarminDeviceCount';
+  /** Number of activities for this device label. */
+  activity_count: Scalars['Int']['output'];
+  /** Device model label, or Manual when an activity has no recording device. */
+  label: Scalars['String']['output'];
+};
+
 /** Result payload returned when triggering an on-demand Garmin sync. */
 export type GarminSyncTriggerResult = {
   __typename?: 'GarminSyncTriggerResult';
@@ -673,6 +682,8 @@ export type Query = {
   garminChartData: Array<GarminChartPoint>;
   /** Get the earliest and latest Garmin activity timestamps. */
   garminDateRange: GarminDateRange;
+  /** List Garmin recording device labels with activity counts. */
+  garminDeviceCounts: Array<GarminDeviceCount>;
   /** List all distinct sport types with activity counts. */
   garminSports: Array<SportInfo>;
   /** Retrieve paginated GPS track points for a Garmin activity. */
@@ -1007,6 +1018,7 @@ export type ResolversTypes = ResolversObject<{
   GarminChartPoint: ResolverTypeWrapper<GarminChartPoint>;
   GarminDateRange: ResolverTypeWrapper<GarminDateRange>;
   GarminDevice: ResolverTypeWrapper<GarminDevice>;
+  GarminDeviceCount: ResolverTypeWrapper<GarminDeviceCount>;
   GarminSyncTriggerResult: ResolverTypeWrapper<GarminSyncTriggerResult>;
   GarminTrackPoint: ResolverTypeWrapper<GarminTrackPoint>;
   GarminTrackPointConnection: ResolverTypeWrapper<GarminTrackPointConnection>;
@@ -1055,6 +1067,7 @@ export type ResolversParentTypes = ResolversObject<{
   GarminChartPoint: GarminChartPoint;
   GarminDateRange: GarminDateRange;
   GarminDevice: GarminDevice;
+  GarminDeviceCount: GarminDeviceCount;
   GarminSyncTriggerResult: GarminSyncTriggerResult;
   GarminTrackPoint: GarminTrackPoint;
   GarminTrackPointConnection: GarminTrackPointConnection;
@@ -1235,6 +1248,11 @@ export type GarminDeviceResolvers<ContextType = GatewayContext, ParentType exten
   manufacturer?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   model?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   software_version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type GarminDeviceCountResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminDeviceCount'] = ResolversParentTypes['GarminDeviceCount']> = ResolversObject<{
+  activity_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 }>;
 
 export type GarminSyncTriggerResultResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminSyncTriggerResult'] = ResolversParentTypes['GarminSyncTriggerResult']> = ResolversObject<{
@@ -1432,6 +1450,7 @@ export type QueryResolvers<ContextType = GatewayContext, ParentType extends Reso
   garminActivityTotals?: Resolver<Array<ResolversTypes['GarminActivityTotal']>, ParentType, ContextType, RequireFields<QueryGarminActivityTotalsArgs, 'period'>>;
   garminChartData?: Resolver<Array<ResolversTypes['GarminChartPoint']>, ParentType, ContextType, RequireFields<QueryGarminChartDataArgs, 'activity_id'>>;
   garminDateRange?: Resolver<ResolversTypes['GarminDateRange'], ParentType, ContextType>;
+  garminDeviceCounts?: Resolver<Array<ResolversTypes['GarminDeviceCount']>, ParentType, ContextType>;
   garminSports?: Resolver<Array<ResolversTypes['SportInfo']>, ParentType, ContextType>;
   garminTrackPoints?: Resolver<ResolversTypes['GarminTrackPointConnection'], ParentType, ContextType, RequireFields<QueryGarminTrackPointsArgs, 'activity_id'>>;
   geocodingStatus?: Resolver<ResolversTypes['GeocodingStatus'], ParentType, ContextType>;
@@ -1511,6 +1530,7 @@ export type Resolvers<ContextType = GatewayContext> = ResolversObject<{
   GarminChartPoint?: GarminChartPointResolvers<ContextType>;
   GarminDateRange?: GarminDateRangeResolvers<ContextType>;
   GarminDevice?: GarminDeviceResolvers<ContextType>;
+  GarminDeviceCount?: GarminDeviceCountResolvers<ContextType>;
   GarminSyncTriggerResult?: GarminSyncTriggerResultResolvers<ContextType>;
   GarminTrackPoint?: GarminTrackPointResolvers<ContextType>;
   GarminTrackPointConnection?: GarminTrackPointConnectionResolvers<ContextType>;

--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -34,6 +34,11 @@ interface CacheEntry<T> {
   expiry: number;
 }
 
+interface GarminDeviceCount {
+  label: string;
+  activity_count: number;
+}
+
 /** Map that evicts expired entries on access, preventing unbounded growth. */
 class ExpiringCache<K, V extends { expiry: number }> extends Map<K, V> {
   override get(key: K): V | undefined {
@@ -290,6 +295,13 @@ export class OtelDataAPI {
   async getGarminSports() {
     return this.fetch<Schemas['SportInfo'][]>({
       path: '/api/v1/garmin/sports',
+      cacheTtlMs: 60_000,
+    });
+  }
+
+  async getGarminDeviceCounts(): Promise<GarminDeviceCount[]> {
+    return this.fetch<GarminDeviceCount[]>({
+      path: '/api/v1/garmin/device-counts',
       cacheTtlMs: 60_000,
     });
   }

--- a/src/resolvers/garmin.ts
+++ b/src/resolvers/garmin.ts
@@ -8,6 +8,7 @@ export const garminResolvers: {
     | 'garminActivity'
     | 'garminTrackPoints'
     | 'garminSports'
+    | 'garminDeviceCounts'
     | 'garminChartData'
     | 'garminActivityTotals'
     | 'garminActivityAddresses'
@@ -59,6 +60,10 @@ export const garminResolvers: {
 
     garminSports: async (_parent, _args, { dataSources }) => {
       return dataSources.otelAPI.getGarminSports();
+    },
+
+    garminDeviceCounts: async (_parent, _args, { dataSources }) => {
+      return dataSources.otelAPI.getGarminDeviceCounts();
     },
 
     garminChartData: async (_parent, args, { dataSources }) => {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -907,6 +907,20 @@ type SportInfo {
 }
 
 """
+Garmin activity count grouped by recording device model.
+"""
+type GarminDeviceCount {
+  """
+  Device model label, or Manual when an activity has no recording device.
+  """
+  label: String!
+  """
+  Number of activities for this device label.
+  """
+  activity_count: Int!
+}
+
+"""
 Lightweight track point optimised for time-series chart rendering.
 """
 type GarminChartPoint {
@@ -1491,6 +1505,11 @@ type Query {
   List all distinct sport types with activity counts.
   """
   garminSports: [SportInfo!]!
+
+  """
+  List Garmin recording device labels with activity counts.
+  """
+  garminDeviceCounts: [GarminDeviceCount!]!
 
   """
   Retrieve chart-optimised track points for a Garmin activity.

--- a/tests/datasources/OtelDataAPI.test.ts
+++ b/tests/datasources/OtelDataAPI.test.ts
@@ -318,6 +318,7 @@ describe('OtelDataAPI', () => {
     await api.getGarminActivity('ga-1');
     await api.getGarminTrackPoints('ga-1', { limit: 2 });
     await api.getGarminSports();
+    await api.getGarminDeviceCounts();
     await api.getGarminChartData('ga-1');
     await api.getGarminActivityTotals({ period: 'week' });
     await api.triggerGarminSync({ window_hours: 24 });
@@ -346,6 +347,7 @@ describe('OtelDataAPI', () => {
       '/api/v1/garmin/activities/ga-1',
       '/api/v1/garmin/activities/ga-1/tracks',
       '/api/v1/garmin/sports',
+      '/api/v1/garmin/device-counts',
       '/api/v1/garmin/activities/ga-1/chart-data',
       '/api/v1/garmin/activity-totals',
       '/api/v1/garmin/sync',
@@ -439,6 +441,29 @@ describe('OtelDataAPI', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
     nowSpy.mockRestore();
+  });
+
+  it('fetches Garmin device counts from the aggregate endpoint', async () => {
+    fetchMock.mockImplementation(() =>
+      jsonResponse([
+        { label: 'Edge 500', activity_count: 2 },
+        { label: 'Edge 540 Solar', activity_count: 1 },
+        { label: 'Manual', activity_count: 1 },
+      ]),
+    );
+    const api = new OtelDataAPI('https://example.test');
+
+    const counts = await api.getGarminDeviceCounts();
+
+    expect(counts).toEqual([
+      { label: 'Edge 500', activity_count: 2 },
+      { label: 'Edge 540 Solar', activity_count: 1 },
+      { label: 'Manual', activity_count: 1 },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'https://example.test/api/v1/garmin/device-counts',
+    );
   });
 
   it('caches garminActivity responses for 30s', async () => {

--- a/tests/resolvers/resolvers.test.ts
+++ b/tests/resolvers/resolvers.test.ts
@@ -163,15 +163,18 @@ describe('garmin resolvers', () => {
     const ctx = contextWith({
       getGarminActivity: mockAsync({ activity_id: 'abc' }),
       getGarminSports: mockAsync(['cycling']),
+      getGarminDeviceCounts: mockAsync([{ label: 'Edge 500', activity_count: 2 }]),
       getGarminChartData: mockAsync([{ timestamp: 'now' }]),
     });
 
     await runResolver(garminResolvers.Query.garminActivity, { activity_id: 'abc' }, ctx);
     await runResolver(garminResolvers.Query.garminSports, {}, ctx);
+    await runResolver(garminResolvers.Query.garminDeviceCounts, {}, ctx);
     await runResolver(garminResolvers.Query.garminChartData, { activity_id: 'abc' }, ctx);
 
     expect(ctx.dataSources.otelAPI.getGarminActivity).toHaveBeenCalledWith('abc');
     expect(ctx.dataSources.otelAPI.getGarminSports).toHaveBeenCalled();
+    expect(ctx.dataSources.otelAPI.getGarminDeviceCounts).toHaveBeenCalled();
     expect(ctx.dataSources.otelAPI.getGarminChartData).toHaveBeenCalledWith('abc');
   });
 

--- a/tests/schema/typeDefs.test.ts
+++ b/tests/schema/typeDefs.test.ts
@@ -145,4 +145,35 @@ describe('typeDefs', () => {
       },
     });
   });
+
+  it('exposes Garmin device activity counts', async () => {
+    const schema = buildSchema(typeDefs);
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          garminDeviceCounts {
+            label
+            activity_count
+          }
+        }
+      `,
+      rootValue: {
+        garminDeviceCounts: () => [
+          { label: 'Edge 500', activity_count: 1237 },
+          { label: 'Edge 540 Solar', activity_count: 194 },
+          { label: 'Manual', activity_count: 5 },
+        ],
+      },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      garminDeviceCounts: [
+        { label: 'Edge 500', activity_count: 1237 },
+        { label: 'Edge 540 Solar', activity_count: 194 },
+        { label: 'Manual', activity_count: 5 },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds a lightweight Garmin device-count GraphQL query backed by the deployed API endpoint.

- Adds `GarminDeviceCount` and `Query.garminDeviceCounts` to the Gateway schema
- Calls `GET /api/v1/garmin/device-counts` from the Gateway datasource with a short cache TTL
- Wires the Garmin resolver to the new datasource method
- Regenerates Gateway GraphQL type artifacts
- Adds datasource, resolver, and schema tests

## Why

The dashboard needs Garmin device/manual activity counts without paging through all Garmin activities. The API now provides this aggregate directly, and Gateway exposes it as a small GraphQL query for UI consumers.

## Validation

- `npm run test`
- `npm run type-check`
- `npm run build`
- `npm run lint:all`
- pre-push checks passed
