### PR TITLE
[codex] Add Garmin activity climbs GraphQL query

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -214,6 +214,81 @@ export interface GarminActivityAddress {
   waypoint_kind: Scalars['String']['output'];
 }
 
+/** Garmin-native ClimbPro typed split for an activity. */
+export interface GarminActivityClimb {
+  __typename?: 'GarminActivityClimb';
+  /** Parent Garmin activity identifier */
+  activity_id: Scalars['String']['output'];
+  /** Average elapsed vertical speed in meters per second */
+  average_elapsed_vertical_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Average climb grade percent */
+  average_grade_percent?: Maybe<Scalars['Float']['output']>;
+  /** Average moving speed in meters per second */
+  average_moving_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Average speed in meters per second */
+  average_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Average temperature in degrees C */
+  average_temperature_c?: Maybe<Scalars['Float']['output']>;
+  /** Average vertical speed in meters per second */
+  average_vertical_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** BMR calories recorded for this climb */
+  bmr_calories?: Maybe<Scalars['Float']['output']>;
+  /** Calories recorded for this climb */
+  calories?: Maybe<Scalars['Float']['output']>;
+  /** Garmin ClimbPro difficulty */
+  climb_pro_difficulty?: Maybe<Scalars['String']['output']>;
+  /** Garmin ClimbPro typed split type */
+  climb_type?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when the row was inserted */
+  created_at?: Maybe<Scalars['String']['output']>;
+  /** Climb distance in meters */
+  distance_meters?: Maybe<Scalars['Float']['output']>;
+  /** Climb duration in seconds */
+  duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Elapsed climb duration in seconds */
+  elapsed_duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Climb elevation gain in meters */
+  elevation_gain_meters?: Maybe<Scalars['Float']['output']>;
+  /** Climb elevation loss in meters */
+  elevation_loss_meters?: Maybe<Scalars['Float']['output']>;
+  /** Climb end latitude */
+  end_latitude?: Maybe<Scalars['Float']['output']>;
+  /** Climb end longitude */
+  end_longitude?: Maybe<Scalars['Float']['output']>;
+  /** UTC climb end time */
+  end_time?: Maybe<Scalars['String']['output']>;
+  /** Unique climb row identifier */
+  id: Scalars['Float']['output'];
+  /** Maximum climb grade percent */
+  max_grade_percent?: Maybe<Scalars['Float']['output']>;
+  /** Maximum speed in meters per second */
+  max_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Maximum temperature in degrees C */
+  max_temperature_c?: Maybe<Scalars['Float']['output']>;
+  /** Garmin message index */
+  message_index?: Maybe<Scalars['Int']['output']>;
+  /** Minimum temperature in degrees C */
+  min_temperature_c?: Maybe<Scalars['Float']['output']>;
+  /** Moving climb duration in seconds */
+  moving_duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Zero-based Garmin typed split order */
+  source_split_index: Scalars['Int']['output'];
+  /** Garmin split type label when provided */
+  split_type?: Maybe<Scalars['String']['output']>;
+  /** Climb start elevation in meters */
+  start_elevation_meters?: Maybe<Scalars['Float']['output']>;
+  /** Climb start latitude */
+  start_latitude?: Maybe<Scalars['Float']['output']>;
+  /** Climb start longitude */
+  start_longitude?: Maybe<Scalars['Float']['output']>;
+  /** UTC climb start time */
+  start_time?: Maybe<Scalars['String']['output']>;
+  /** Local climb start time from Garmin */
+  start_time_local?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when the row was last updated */
+  updated_at?: Maybe<Scalars['String']['output']>;
+}
+
 /** Paginated list of Garmin activities. */
 export interface GarminActivityConnection {
   __typename?: 'GarminActivityConnection';
@@ -671,6 +746,8 @@ export interface Query {
   garminActivity?: Maybe<GarminActivity>;
   /** Retrieve all reverse-geocoded addresses for a Garmin activity (start, mid-route waypoints, and end). */
   garminActivityAddresses: Array<GarminActivityAddress>;
+  /** Retrieve Garmin-native ClimbPro typed splits for a Garmin activity. */
+  garminActivityClimbs: Array<GarminActivityClimb>;
   /** Aggregate Garmin activity totals grouped by week, month, or year. */
   garminActivityTotals: Array<GarminActivityTotal>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
@@ -738,6 +815,10 @@ export interface QueryGarminActivityArgs {
 }
 
 export interface QueryGarminActivityAddressesArgs {
+  activity_id: Scalars['String']['input'];
+}
+
+export interface QueryGarminActivityClimbsArgs {
   activity_id: Scalars['String']['input'];
 }
 

--- a/packages/graphql-types/schema.graphql
+++ b/packages/graphql-types/schema.graphql
@@ -669,6 +669,152 @@ type GarminDateRange {
 }
 
 """
+Garmin-native ClimbPro typed split for an activity.
+"""
+type GarminActivityClimb {
+  """
+  Unique climb row identifier
+  """
+  id: Float!
+  """
+  Parent Garmin activity identifier
+  """
+  activity_id: String!
+  """
+  Zero-based Garmin typed split order
+  """
+  source_split_index: Int!
+  """
+  Garmin message index
+  """
+  message_index: Int
+  """
+  Garmin split type label when provided
+  """
+  split_type: String
+  """
+  Garmin ClimbPro typed split type
+  """
+  climb_type: String
+  """
+  UTC climb start time
+  """
+  start_time: String
+  """
+  UTC climb end time
+  """
+  end_time: String
+  """
+  Local climb start time from Garmin
+  """
+  start_time_local: String
+  """
+  Climb duration in seconds
+  """
+  duration_seconds: Float
+  """
+  Elapsed climb duration in seconds
+  """
+  elapsed_duration_seconds: Float
+  """
+  Moving climb duration in seconds
+  """
+  moving_duration_seconds: Float
+  """
+  Climb distance in meters
+  """
+  distance_meters: Float
+  """
+  Climb elevation gain in meters
+  """
+  elevation_gain_meters: Float
+  """
+  Climb elevation loss in meters
+  """
+  elevation_loss_meters: Float
+  """
+  Climb start elevation in meters
+  """
+  start_elevation_meters: Float
+  """
+  Average climb grade percent
+  """
+  average_grade_percent: Float
+  """
+  Maximum climb grade percent
+  """
+  max_grade_percent: Float
+  """
+  Average speed in meters per second
+  """
+  average_speed_mps: Float
+  """
+  Average moving speed in meters per second
+  """
+  average_moving_speed_mps: Float
+  """
+  Maximum speed in meters per second
+  """
+  max_speed_mps: Float
+  """
+  Average vertical speed in meters per second
+  """
+  average_vertical_speed_mps: Float
+  """
+  Average elapsed vertical speed in meters per second
+  """
+  average_elapsed_vertical_speed_mps: Float
+  """
+  Climb start latitude
+  """
+  start_latitude: Float
+  """
+  Climb start longitude
+  """
+  start_longitude: Float
+  """
+  Climb end latitude
+  """
+  end_latitude: Float
+  """
+  Climb end longitude
+  """
+  end_longitude: Float
+  """
+  Garmin ClimbPro difficulty
+  """
+  climb_pro_difficulty: String
+  """
+  Calories recorded for this climb
+  """
+  calories: Float
+  """
+  BMR calories recorded for this climb
+  """
+  bmr_calories: Float
+  """
+  Average temperature in degrees C
+  """
+  average_temperature_c: Float
+  """
+  Minimum temperature in degrees C
+  """
+  min_temperature_c: Float
+  """
+  Maximum temperature in degrees C
+  """
+  max_temperature_c: Float
+  """
+  UTC timestamp when the row was inserted
+  """
+  created_at: String
+  """
+  UTC timestamp when the row was last updated
+  """
+  updated_at: String
+}
+
+"""
 Individual GPS track point within a Garmin activity.
 """
 type GarminTrackPoint {
@@ -1520,6 +1666,16 @@ type Query {
     """
     activity_id: String!
   ): [GarminChartPoint!]!
+
+  """
+  Retrieve Garmin-native ClimbPro typed splits for a Garmin activity.
+  """
+  garminActivityClimbs(
+    """
+    Garmin Connect activity identifier
+    """
+    activity_id: String!
+  ): [GarminActivityClimb!]!
 
   """
   Retrieve all reverse-geocoded addresses for a Garmin activity (start, mid-route waypoints, and end).

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -217,6 +217,81 @@ export type GarminActivityAddress = {
   waypoint_kind: Scalars['String']['output'];
 };
 
+/** Garmin-native ClimbPro typed split for an activity. */
+export type GarminActivityClimb = {
+  __typename?: 'GarminActivityClimb';
+  /** Parent Garmin activity identifier */
+  activity_id: Scalars['String']['output'];
+  /** Average elapsed vertical speed in meters per second */
+  average_elapsed_vertical_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Average climb grade percent */
+  average_grade_percent?: Maybe<Scalars['Float']['output']>;
+  /** Average moving speed in meters per second */
+  average_moving_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Average speed in meters per second */
+  average_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Average temperature in degrees C */
+  average_temperature_c?: Maybe<Scalars['Float']['output']>;
+  /** Average vertical speed in meters per second */
+  average_vertical_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** BMR calories recorded for this climb */
+  bmr_calories?: Maybe<Scalars['Float']['output']>;
+  /** Calories recorded for this climb */
+  calories?: Maybe<Scalars['Float']['output']>;
+  /** Garmin ClimbPro difficulty */
+  climb_pro_difficulty?: Maybe<Scalars['String']['output']>;
+  /** Garmin ClimbPro typed split type */
+  climb_type?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when the row was inserted */
+  created_at?: Maybe<Scalars['String']['output']>;
+  /** Climb distance in meters */
+  distance_meters?: Maybe<Scalars['Float']['output']>;
+  /** Climb duration in seconds */
+  duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Elapsed climb duration in seconds */
+  elapsed_duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Climb elevation gain in meters */
+  elevation_gain_meters?: Maybe<Scalars['Float']['output']>;
+  /** Climb elevation loss in meters */
+  elevation_loss_meters?: Maybe<Scalars['Float']['output']>;
+  /** Climb end latitude */
+  end_latitude?: Maybe<Scalars['Float']['output']>;
+  /** Climb end longitude */
+  end_longitude?: Maybe<Scalars['Float']['output']>;
+  /** UTC climb end time */
+  end_time?: Maybe<Scalars['String']['output']>;
+  /** Unique climb row identifier */
+  id: Scalars['Float']['output'];
+  /** Maximum climb grade percent */
+  max_grade_percent?: Maybe<Scalars['Float']['output']>;
+  /** Maximum speed in meters per second */
+  max_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Maximum temperature in degrees C */
+  max_temperature_c?: Maybe<Scalars['Float']['output']>;
+  /** Garmin message index */
+  message_index?: Maybe<Scalars['Int']['output']>;
+  /** Minimum temperature in degrees C */
+  min_temperature_c?: Maybe<Scalars['Float']['output']>;
+  /** Moving climb duration in seconds */
+  moving_duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Zero-based Garmin typed split order */
+  source_split_index: Scalars['Int']['output'];
+  /** Garmin split type label when provided */
+  split_type?: Maybe<Scalars['String']['output']>;
+  /** Climb start elevation in meters */
+  start_elevation_meters?: Maybe<Scalars['Float']['output']>;
+  /** Climb start latitude */
+  start_latitude?: Maybe<Scalars['Float']['output']>;
+  /** Climb start longitude */
+  start_longitude?: Maybe<Scalars['Float']['output']>;
+  /** UTC climb start time */
+  start_time?: Maybe<Scalars['String']['output']>;
+  /** Local climb start time from Garmin */
+  start_time_local?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when the row was last updated */
+  updated_at?: Maybe<Scalars['String']['output']>;
+};
+
 /** Paginated list of Garmin activities. */
 export type GarminActivityConnection = {
   __typename?: 'GarminActivityConnection';
@@ -676,6 +751,8 @@ export type Query = {
   garminActivity?: Maybe<GarminActivity>;
   /** Retrieve all reverse-geocoded addresses for a Garmin activity (start, mid-route waypoints, and end). */
   garminActivityAddresses: Array<GarminActivityAddress>;
+  /** Retrieve Garmin-native ClimbPro typed splits for a Garmin activity. */
+  garminActivityClimbs: Array<GarminActivityClimb>;
   /** Aggregate Garmin activity totals grouped by week, month, or year. */
   garminActivityTotals: Array<GarminActivityTotal>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
@@ -748,6 +825,11 @@ export type QueryGarminActivityArgs = {
 
 
 export type QueryGarminActivityAddressesArgs = {
+  activity_id: Scalars['String']['input'];
+};
+
+
+export type QueryGarminActivityClimbsArgs = {
   activity_id: Scalars['String']['input'];
 };
 
@@ -1013,6 +1095,7 @@ export type ResolversTypes = ResolversObject<{
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   GarminActivity: ResolverTypeWrapper<GarminActivity>;
   GarminActivityAddress: ResolverTypeWrapper<GarminActivityAddress>;
+  GarminActivityClimb: ResolverTypeWrapper<GarminActivityClimb>;
   GarminActivityConnection: ResolverTypeWrapper<GarminActivityConnection>;
   GarminActivityTotal: ResolverTypeWrapper<GarminActivityTotal>;
   GarminChartPoint: ResolverTypeWrapper<GarminChartPoint>;
@@ -1062,6 +1145,7 @@ export type ResolversParentTypes = ResolversObject<{
   Float: Scalars['Float']['output'];
   GarminActivity: GarminActivity;
   GarminActivityAddress: GarminActivityAddress;
+  GarminActivityClimb: GarminActivityClimb;
   GarminActivityConnection: GarminActivityConnection;
   GarminActivityTotal: GarminActivityTotal;
   GarminChartPoint: GarminChartPoint;
@@ -1205,6 +1289,44 @@ export type GarminActivityAddressResolvers<ContextType = GatewayContext, ParentT
   timestamp?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   track_point_id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   waypoint_kind?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type GarminActivityClimbResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminActivityClimb'] = ResolversParentTypes['GarminActivityClimb']> = ResolversObject<{
+  activity_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  average_elapsed_vertical_speed_mps?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  average_grade_percent?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  average_moving_speed_mps?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  average_speed_mps?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  average_temperature_c?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  average_vertical_speed_mps?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  bmr_calories?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  calories?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  climb_pro_difficulty?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  climb_type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  created_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  distance_meters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  duration_seconds?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  elapsed_duration_seconds?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  elevation_gain_meters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  elevation_loss_meters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  end_latitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  end_longitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  end_time?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  max_grade_percent?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  max_speed_mps?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  max_temperature_c?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  message_index?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  min_temperature_c?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  moving_duration_seconds?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  source_split_index?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  split_type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  start_elevation_meters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  start_latitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  start_longitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  start_time?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  start_time_local?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  updated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type GarminActivityConnectionResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminActivityConnection'] = ResolversParentTypes['GarminActivityConnection']> = ResolversObject<{
@@ -1447,6 +1569,7 @@ export type QueryResolvers<ContextType = GatewayContext, ParentType extends Reso
   garminActivities?: Resolver<ResolversTypes['GarminActivityConnection'], ParentType, ContextType, Partial<QueryGarminActivitiesArgs>>;
   garminActivity?: Resolver<Maybe<ResolversTypes['GarminActivity']>, ParentType, ContextType, RequireFields<QueryGarminActivityArgs, 'activity_id'>>;
   garminActivityAddresses?: Resolver<Array<ResolversTypes['GarminActivityAddress']>, ParentType, ContextType, RequireFields<QueryGarminActivityAddressesArgs, 'activity_id'>>;
+  garminActivityClimbs?: Resolver<Array<ResolversTypes['GarminActivityClimb']>, ParentType, ContextType, RequireFields<QueryGarminActivityClimbsArgs, 'activity_id'>>;
   garminActivityTotals?: Resolver<Array<ResolversTypes['GarminActivityTotal']>, ParentType, ContextType, RequireFields<QueryGarminActivityTotalsArgs, 'period'>>;
   garminChartData?: Resolver<Array<ResolversTypes['GarminChartPoint']>, ParentType, ContextType, RequireFields<QueryGarminChartDataArgs, 'activity_id'>>;
   garminDateRange?: Resolver<ResolversTypes['GarminDateRange'], ParentType, ContextType>;
@@ -1525,6 +1648,7 @@ export type Resolvers<ContextType = GatewayContext> = ResolversObject<{
   DistanceResult?: DistanceResultResolvers<ContextType>;
   GarminActivity?: GarminActivityResolvers<ContextType>;
   GarminActivityAddress?: GarminActivityAddressResolvers<ContextType>;
+  GarminActivityClimb?: GarminActivityClimbResolvers<ContextType>;
   GarminActivityConnection?: GarminActivityConnectionResolvers<ContextType>;
   GarminActivityTotal?: GarminActivityTotalResolvers<ContextType>;
   GarminChartPoint?: GarminChartPointResolvers<ContextType>;

--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -39,6 +39,44 @@ interface GarminDeviceCount {
   activity_count: number;
 }
 
+interface GarminActivityClimb {
+  id: number;
+  activity_id: string;
+  source_split_index: number;
+  message_index: number | null;
+  split_type: string | null;
+  climb_type: string | null;
+  start_time: string | null;
+  end_time: string | null;
+  start_time_local: string | null;
+  duration_seconds: number | null;
+  elapsed_duration_seconds: number | null;
+  moving_duration_seconds: number | null;
+  distance_meters: number | null;
+  elevation_gain_meters: number | null;
+  elevation_loss_meters: number | null;
+  start_elevation_meters: number | null;
+  average_grade_percent: number | null;
+  max_grade_percent: number | null;
+  average_speed_mps: number | null;
+  average_moving_speed_mps: number | null;
+  max_speed_mps: number | null;
+  average_vertical_speed_mps: number | null;
+  average_elapsed_vertical_speed_mps: number | null;
+  start_latitude: number | null;
+  start_longitude: number | null;
+  end_latitude: number | null;
+  end_longitude: number | null;
+  climb_pro_difficulty: string | null;
+  calories: number | null;
+  bmr_calories: number | null;
+  average_temperature_c: number | null;
+  min_temperature_c: number | null;
+  max_temperature_c: number | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
 /** Map that evicts expired entries on access, preventing unbounded growth. */
 class ExpiringCache<K, V extends { expiry: number }> extends Map<K, V> {
   override get(key: K): V | undefined {
@@ -309,6 +347,13 @@ export class OtelDataAPI {
   async getGarminChartData(activityId: string) {
     return this.fetch<Schemas['GarminChartPoint'][]>({
       path: `/api/v1/garmin/activities/${activityId}/chart-data`,
+      cacheTtlMs: 30_000,
+    });
+  }
+
+  async getGarminActivityClimbs(activityId: string): Promise<GarminActivityClimb[]> {
+    return this.fetch<GarminActivityClimb[]>({
+      path: `/api/v1/garmin/activities/${activityId}/climbs`,
       cacheTtlMs: 30_000,
     });
   }

--- a/src/resolvers/garmin.ts
+++ b/src/resolvers/garmin.ts
@@ -10,6 +10,7 @@ export const garminResolvers: {
     | 'garminSports'
     | 'garminDeviceCounts'
     | 'garminChartData'
+    | 'garminActivityClimbs'
     | 'garminActivityTotals'
     | 'garminActivityAddresses'
   >;
@@ -68,6 +69,10 @@ export const garminResolvers: {
 
     garminChartData: async (_parent, args, { dataSources }) => {
       return dataSources.otelAPI.getGarminChartData(args.activity_id);
+    },
+
+    garminActivityClimbs: async (_parent, args, { dataSources }) => {
+      return dataSources.otelAPI.getGarminActivityClimbs(args.activity_id);
     },
 
     garminActivityTotals: async (_parent, args, { dataSources }) => {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -669,6 +669,152 @@ type GarminDateRange {
 }
 
 """
+Garmin-native ClimbPro typed split for an activity.
+"""
+type GarminActivityClimb {
+  """
+  Unique climb row identifier
+  """
+  id: Float!
+  """
+  Parent Garmin activity identifier
+  """
+  activity_id: String!
+  """
+  Zero-based Garmin typed split order
+  """
+  source_split_index: Int!
+  """
+  Garmin message index
+  """
+  message_index: Int
+  """
+  Garmin split type label when provided
+  """
+  split_type: String
+  """
+  Garmin ClimbPro typed split type
+  """
+  climb_type: String
+  """
+  UTC climb start time
+  """
+  start_time: String
+  """
+  UTC climb end time
+  """
+  end_time: String
+  """
+  Local climb start time from Garmin
+  """
+  start_time_local: String
+  """
+  Climb duration in seconds
+  """
+  duration_seconds: Float
+  """
+  Elapsed climb duration in seconds
+  """
+  elapsed_duration_seconds: Float
+  """
+  Moving climb duration in seconds
+  """
+  moving_duration_seconds: Float
+  """
+  Climb distance in meters
+  """
+  distance_meters: Float
+  """
+  Climb elevation gain in meters
+  """
+  elevation_gain_meters: Float
+  """
+  Climb elevation loss in meters
+  """
+  elevation_loss_meters: Float
+  """
+  Climb start elevation in meters
+  """
+  start_elevation_meters: Float
+  """
+  Average climb grade percent
+  """
+  average_grade_percent: Float
+  """
+  Maximum climb grade percent
+  """
+  max_grade_percent: Float
+  """
+  Average speed in meters per second
+  """
+  average_speed_mps: Float
+  """
+  Average moving speed in meters per second
+  """
+  average_moving_speed_mps: Float
+  """
+  Maximum speed in meters per second
+  """
+  max_speed_mps: Float
+  """
+  Average vertical speed in meters per second
+  """
+  average_vertical_speed_mps: Float
+  """
+  Average elapsed vertical speed in meters per second
+  """
+  average_elapsed_vertical_speed_mps: Float
+  """
+  Climb start latitude
+  """
+  start_latitude: Float
+  """
+  Climb start longitude
+  """
+  start_longitude: Float
+  """
+  Climb end latitude
+  """
+  end_latitude: Float
+  """
+  Climb end longitude
+  """
+  end_longitude: Float
+  """
+  Garmin ClimbPro difficulty
+  """
+  climb_pro_difficulty: String
+  """
+  Calories recorded for this climb
+  """
+  calories: Float
+  """
+  BMR calories recorded for this climb
+  """
+  bmr_calories: Float
+  """
+  Average temperature in degrees C
+  """
+  average_temperature_c: Float
+  """
+  Minimum temperature in degrees C
+  """
+  min_temperature_c: Float
+  """
+  Maximum temperature in degrees C
+  """
+  max_temperature_c: Float
+  """
+  UTC timestamp when the row was inserted
+  """
+  created_at: String
+  """
+  UTC timestamp when the row was last updated
+  """
+  updated_at: String
+}
+
+"""
 Individual GPS track point within a Garmin activity.
 """
 type GarminTrackPoint {
@@ -1520,6 +1666,16 @@ type Query {
     """
     activity_id: String!
   ): [GarminChartPoint!]!
+
+  """
+  Retrieve Garmin-native ClimbPro typed splits for a Garmin activity.
+  """
+  garminActivityClimbs(
+    """
+    Garmin Connect activity identifier
+    """
+    activity_id: String!
+  ): [GarminActivityClimb!]!
 
   """
   Retrieve all reverse-geocoded addresses for a Garmin activity (start, mid-route waypoints, and end).


### PR DESCRIPTION
## Summary
- Adds GarminActivityClimb GraphQL type.
- Adds garminActivityClimbs(activity_id) query.
- Regenerates resolver and @stuartshay/otel-graphql-types package artifacts.

## Validation
- npm run build:types-package
- npm run lint:all
- npm run type-check
- npm run test
- GraphQL smoke test returned 6 climb rows for activity 22109228769 against local API.

## Dependency
- Requires the API PR and published @stuartshay/otel-data-types update for the deployed gateway path.
