### PR TITLE
[codex] Add Garmin activity laps GraphQL query

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ open http://localhost:4000
 | `garminTrackPoints`  | `/api/v1/garmin/.../tracks`        | Track points        |
 | `garminSports`       | `/api/v1/garmin/sports`            | Sport types         |
 | `garminChartData`    | `/api/v1/garmin/.../chart-data`    | Chart data points   |
+| `garminActivityLaps` | `/api/v1/garmin/.../laps`          | Activity laps       |
 | `unifiedGps`         | `/api/v1/gps/unified`              | Unified GPS points  |
 | `dailySummary`       | `/api/v1/gps/daily-summary`        | Daily summary       |
 | `referenceLocations` | `/api/v1/reference-locations`      | Reference locations |

--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -302,6 +302,49 @@ export interface GarminActivityConnection {
   total: Scalars['Int']['output'];
 }
 
+/** Garmin-native or derived activity lap row. */
+export interface GarminActivityLap {
+  __typename?: 'GarminActivityLap';
+  /** Parent Garmin activity identifier */
+  activity_id: Scalars['String']['output'];
+  /** Average lap heart rate in bpm */
+  avg_heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Average lap speed in meters per second */
+  avg_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Calories recorded for this lap */
+  calories?: Maybe<Scalars['Float']['output']>;
+  /** UTC timestamp when the row was inserted */
+  created_at?: Maybe<Scalars['String']['output']>;
+  /** Lap distance in meters */
+  distance_meters?: Maybe<Scalars['Float']['output']>;
+  /** Lap timer duration in seconds */
+  duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Lap elapsed duration in seconds */
+  elapsed_duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** UTC lap end time */
+  end_time?: Maybe<Scalars['String']['output']>;
+  /** Unique lap row identifier */
+  id: Scalars['Float']['output'];
+  /** One-based lap order within the activity */
+  lap_index: Scalars['Int']['output'];
+  /** Maximum lap heart rate in bpm */
+  max_heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Lap moving duration in seconds */
+  moving_duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Lap paved distance in meters */
+  paved_distance_meters?: Maybe<Scalars['Float']['output']>;
+  /** UTC lap start time */
+  start_time?: Maybe<Scalars['String']['output']>;
+  /** Lap elevation gain in meters */
+  total_ascent_meters?: Maybe<Scalars['Float']['output']>;
+  /** Lap elevation loss in meters */
+  total_descent_meters?: Maybe<Scalars['Float']['output']>;
+  /** Lap unpaved distance in meters */
+  unpaved_distance_meters?: Maybe<Scalars['Float']['output']>;
+  /** UTC timestamp when the row was last updated */
+  updated_at?: Maybe<Scalars['String']['output']>;
+}
+
 /** Aggregated Garmin activity totals for a single time bucket (week, month, or year). */
 export interface GarminActivityTotal {
   __typename?: 'GarminActivityTotal';
@@ -748,6 +791,8 @@ export interface Query {
   garminActivityAddresses: Array<GarminActivityAddress>;
   /** Retrieve Garmin-native ClimbPro typed splits for a Garmin activity. */
   garminActivityClimbs: Array<GarminActivityClimb>;
+  /** Retrieve Garmin-native or derived laps for a Garmin activity. */
+  garminActivityLaps: Array<GarminActivityLap>;
   /** Aggregate Garmin activity totals grouped by week, month, or year. */
   garminActivityTotals: Array<GarminActivityTotal>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
@@ -819,6 +864,10 @@ export interface QueryGarminActivityAddressesArgs {
 }
 
 export interface QueryGarminActivityClimbsArgs {
+  activity_id: Scalars['String']['input'];
+}
+
+export interface QueryGarminActivityLapsArgs {
   activity_id: Scalars['String']['input'];
 }
 

--- a/packages/graphql-types/schema.graphql
+++ b/packages/graphql-types/schema.graphql
@@ -815,6 +815,88 @@ type GarminActivityClimb {
 }
 
 """
+Garmin-native or derived activity lap row.
+"""
+type GarminActivityLap {
+  """
+  Unique lap row identifier
+  """
+  id: Float!
+  """
+  Parent Garmin activity identifier
+  """
+  activity_id: String!
+  """
+  One-based lap order within the activity
+  """
+  lap_index: Int!
+  """
+  UTC lap start time
+  """
+  start_time: String
+  """
+  UTC lap end time
+  """
+  end_time: String
+  """
+  Lap timer duration in seconds
+  """
+  duration_seconds: Float
+  """
+  Lap elapsed duration in seconds
+  """
+  elapsed_duration_seconds: Float
+  """
+  Lap moving duration in seconds
+  """
+  moving_duration_seconds: Float
+  """
+  Lap distance in meters
+  """
+  distance_meters: Float
+  """
+  Lap paved distance in meters
+  """
+  paved_distance_meters: Float
+  """
+  Lap unpaved distance in meters
+  """
+  unpaved_distance_meters: Float
+  """
+  Average lap speed in meters per second
+  """
+  avg_speed_mps: Float
+  """
+  Average lap heart rate in bpm
+  """
+  avg_heart_rate: Int
+  """
+  Maximum lap heart rate in bpm
+  """
+  max_heart_rate: Int
+  """
+  Lap elevation gain in meters
+  """
+  total_ascent_meters: Float
+  """
+  Lap elevation loss in meters
+  """
+  total_descent_meters: Float
+  """
+  Calories recorded for this lap
+  """
+  calories: Float
+  """
+  UTC timestamp when the row was inserted
+  """
+  created_at: String
+  """
+  UTC timestamp when the row was last updated
+  """
+  updated_at: String
+}
+
+"""
 Individual GPS track point within a Garmin activity.
 """
 type GarminTrackPoint {
@@ -1676,6 +1758,16 @@ type Query {
     """
     activity_id: String!
   ): [GarminActivityClimb!]!
+
+  """
+  Retrieve Garmin-native or derived laps for a Garmin activity.
+  """
+  garminActivityLaps(
+    """
+    Garmin Connect activity identifier
+    """
+    activity_id: String!
+  ): [GarminActivityLap!]!
 
   """
   Retrieve all reverse-geocoded addresses for a Garmin activity (start, mid-route waypoints, and end).

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -305,6 +305,49 @@ export type GarminActivityConnection = {
   total: Scalars['Int']['output'];
 };
 
+/** Garmin-native or derived activity lap row. */
+export type GarminActivityLap = {
+  __typename?: 'GarminActivityLap';
+  /** Parent Garmin activity identifier */
+  activity_id: Scalars['String']['output'];
+  /** Average lap heart rate in bpm */
+  avg_heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Average lap speed in meters per second */
+  avg_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Calories recorded for this lap */
+  calories?: Maybe<Scalars['Float']['output']>;
+  /** UTC timestamp when the row was inserted */
+  created_at?: Maybe<Scalars['String']['output']>;
+  /** Lap distance in meters */
+  distance_meters?: Maybe<Scalars['Float']['output']>;
+  /** Lap timer duration in seconds */
+  duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Lap elapsed duration in seconds */
+  elapsed_duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** UTC lap end time */
+  end_time?: Maybe<Scalars['String']['output']>;
+  /** Unique lap row identifier */
+  id: Scalars['Float']['output'];
+  /** One-based lap order within the activity */
+  lap_index: Scalars['Int']['output'];
+  /** Maximum lap heart rate in bpm */
+  max_heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Lap moving duration in seconds */
+  moving_duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Lap paved distance in meters */
+  paved_distance_meters?: Maybe<Scalars['Float']['output']>;
+  /** UTC lap start time */
+  start_time?: Maybe<Scalars['String']['output']>;
+  /** Lap elevation gain in meters */
+  total_ascent_meters?: Maybe<Scalars['Float']['output']>;
+  /** Lap elevation loss in meters */
+  total_descent_meters?: Maybe<Scalars['Float']['output']>;
+  /** Lap unpaved distance in meters */
+  unpaved_distance_meters?: Maybe<Scalars['Float']['output']>;
+  /** UTC timestamp when the row was last updated */
+  updated_at?: Maybe<Scalars['String']['output']>;
+};
+
 /** Aggregated Garmin activity totals for a single time bucket (week, month, or year). */
 export type GarminActivityTotal = {
   __typename?: 'GarminActivityTotal';
@@ -753,6 +796,8 @@ export type Query = {
   garminActivityAddresses: Array<GarminActivityAddress>;
   /** Retrieve Garmin-native ClimbPro typed splits for a Garmin activity. */
   garminActivityClimbs: Array<GarminActivityClimb>;
+  /** Retrieve Garmin-native or derived laps for a Garmin activity. */
+  garminActivityLaps: Array<GarminActivityLap>;
   /** Aggregate Garmin activity totals grouped by week, month, or year. */
   garminActivityTotals: Array<GarminActivityTotal>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
@@ -830,6 +875,11 @@ export type QueryGarminActivityAddressesArgs = {
 
 
 export type QueryGarminActivityClimbsArgs = {
+  activity_id: Scalars['String']['input'];
+};
+
+
+export type QueryGarminActivityLapsArgs = {
   activity_id: Scalars['String']['input'];
 };
 
@@ -1097,6 +1147,7 @@ export type ResolversTypes = ResolversObject<{
   GarminActivityAddress: ResolverTypeWrapper<GarminActivityAddress>;
   GarminActivityClimb: ResolverTypeWrapper<GarminActivityClimb>;
   GarminActivityConnection: ResolverTypeWrapper<GarminActivityConnection>;
+  GarminActivityLap: ResolverTypeWrapper<GarminActivityLap>;
   GarminActivityTotal: ResolverTypeWrapper<GarminActivityTotal>;
   GarminChartPoint: ResolverTypeWrapper<GarminChartPoint>;
   GarminDateRange: ResolverTypeWrapper<GarminDateRange>;
@@ -1147,6 +1198,7 @@ export type ResolversParentTypes = ResolversObject<{
   GarminActivityAddress: GarminActivityAddress;
   GarminActivityClimb: GarminActivityClimb;
   GarminActivityConnection: GarminActivityConnection;
+  GarminActivityLap: GarminActivityLap;
   GarminActivityTotal: GarminActivityTotal;
   GarminChartPoint: GarminChartPoint;
   GarminDateRange: GarminDateRange;
@@ -1334,6 +1386,28 @@ export type GarminActivityConnectionResolvers<ContextType = GatewayContext, Pare
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   offset?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type GarminActivityLapResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminActivityLap'] = ResolversParentTypes['GarminActivityLap']> = ResolversObject<{
+  activity_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  avg_heart_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  avg_speed_mps?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  calories?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  created_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  distance_meters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  duration_seconds?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  elapsed_duration_seconds?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  end_time?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  lap_index?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  max_heart_rate?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  moving_duration_seconds?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  paved_distance_meters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  start_time?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  total_ascent_meters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  total_descent_meters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  unpaved_distance_meters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  updated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type GarminActivityTotalResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['GarminActivityTotal'] = ResolversParentTypes['GarminActivityTotal']> = ResolversObject<{
@@ -1570,6 +1644,7 @@ export type QueryResolvers<ContextType = GatewayContext, ParentType extends Reso
   garminActivity?: Resolver<Maybe<ResolversTypes['GarminActivity']>, ParentType, ContextType, RequireFields<QueryGarminActivityArgs, 'activity_id'>>;
   garminActivityAddresses?: Resolver<Array<ResolversTypes['GarminActivityAddress']>, ParentType, ContextType, RequireFields<QueryGarminActivityAddressesArgs, 'activity_id'>>;
   garminActivityClimbs?: Resolver<Array<ResolversTypes['GarminActivityClimb']>, ParentType, ContextType, RequireFields<QueryGarminActivityClimbsArgs, 'activity_id'>>;
+  garminActivityLaps?: Resolver<Array<ResolversTypes['GarminActivityLap']>, ParentType, ContextType, RequireFields<QueryGarminActivityLapsArgs, 'activity_id'>>;
   garminActivityTotals?: Resolver<Array<ResolversTypes['GarminActivityTotal']>, ParentType, ContextType, RequireFields<QueryGarminActivityTotalsArgs, 'period'>>;
   garminChartData?: Resolver<Array<ResolversTypes['GarminChartPoint']>, ParentType, ContextType, RequireFields<QueryGarminChartDataArgs, 'activity_id'>>;
   garminDateRange?: Resolver<ResolversTypes['GarminDateRange'], ParentType, ContextType>;
@@ -1650,6 +1725,7 @@ export type Resolvers<ContextType = GatewayContext> = ResolversObject<{
   GarminActivityAddress?: GarminActivityAddressResolvers<ContextType>;
   GarminActivityClimb?: GarminActivityClimbResolvers<ContextType>;
   GarminActivityConnection?: GarminActivityConnectionResolvers<ContextType>;
+  GarminActivityLap?: GarminActivityLapResolvers<ContextType>;
   GarminActivityTotal?: GarminActivityTotalResolvers<ContextType>;
   GarminChartPoint?: GarminChartPointResolvers<ContextType>;
   GarminDateRange?: GarminDateRangeResolvers<ContextType>;

--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -77,6 +77,8 @@ interface GarminActivityClimb {
   updated_at: string | null;
 }
 
+type GarminActivityLap = Schemas['GarminActivityLap'];
+
 /** Map that evicts expired entries on access, preventing unbounded growth. */
 class ExpiringCache<K, V extends { expiry: number }> extends Map<K, V> {
   override get(key: K): V | undefined {
@@ -354,6 +356,13 @@ export class OtelDataAPI {
   async getGarminActivityClimbs(activityId: string): Promise<GarminActivityClimb[]> {
     return this.fetch<GarminActivityClimb[]>({
       path: `/api/v1/garmin/activities/${activityId}/climbs`,
+      cacheTtlMs: 30_000,
+    });
+  }
+
+  async getGarminActivityLaps(activityId: string): Promise<GarminActivityLap[]> {
+    return this.fetch<GarminActivityLap[]>({
+      path: `/api/v1/garmin/activities/${activityId}/laps`,
       cacheTtlMs: 30_000,
     });
   }

--- a/src/resolvers/garmin.ts
+++ b/src/resolvers/garmin.ts
@@ -11,6 +11,7 @@ export const garminResolvers: {
     | 'garminDeviceCounts'
     | 'garminChartData'
     | 'garminActivityClimbs'
+    | 'garminActivityLaps'
     | 'garminActivityTotals'
     | 'garminActivityAddresses'
   >;
@@ -73,6 +74,10 @@ export const garminResolvers: {
 
     garminActivityClimbs: async (_parent, args, { dataSources }) => {
       return dataSources.otelAPI.getGarminActivityClimbs(args.activity_id);
+    },
+
+    garminActivityLaps: async (_parent, args, { dataSources }) => {
+      return dataSources.otelAPI.getGarminActivityLaps(args.activity_id);
     },
 
     garminActivityTotals: async (_parent, args, { dataSources }) => {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -815,6 +815,88 @@ type GarminActivityClimb {
 }
 
 """
+Garmin-native or derived activity lap row.
+"""
+type GarminActivityLap {
+  """
+  Unique lap row identifier
+  """
+  id: Float!
+  """
+  Parent Garmin activity identifier
+  """
+  activity_id: String!
+  """
+  One-based lap order within the activity
+  """
+  lap_index: Int!
+  """
+  UTC lap start time
+  """
+  start_time: String
+  """
+  UTC lap end time
+  """
+  end_time: String
+  """
+  Lap timer duration in seconds
+  """
+  duration_seconds: Float
+  """
+  Lap elapsed duration in seconds
+  """
+  elapsed_duration_seconds: Float
+  """
+  Lap moving duration in seconds
+  """
+  moving_duration_seconds: Float
+  """
+  Lap distance in meters
+  """
+  distance_meters: Float
+  """
+  Lap paved distance in meters
+  """
+  paved_distance_meters: Float
+  """
+  Lap unpaved distance in meters
+  """
+  unpaved_distance_meters: Float
+  """
+  Average lap speed in meters per second
+  """
+  avg_speed_mps: Float
+  """
+  Average lap heart rate in bpm
+  """
+  avg_heart_rate: Int
+  """
+  Maximum lap heart rate in bpm
+  """
+  max_heart_rate: Int
+  """
+  Lap elevation gain in meters
+  """
+  total_ascent_meters: Float
+  """
+  Lap elevation loss in meters
+  """
+  total_descent_meters: Float
+  """
+  Calories recorded for this lap
+  """
+  calories: Float
+  """
+  UTC timestamp when the row was inserted
+  """
+  created_at: String
+  """
+  UTC timestamp when the row was last updated
+  """
+  updated_at: String
+}
+
+"""
 Individual GPS track point within a Garmin activity.
 """
 type GarminTrackPoint {
@@ -1676,6 +1758,16 @@ type Query {
     """
     activity_id: String!
   ): [GarminActivityClimb!]!
+
+  """
+  Retrieve Garmin-native or derived laps for a Garmin activity.
+  """
+  garminActivityLaps(
+    """
+    Garmin Connect activity identifier
+    """
+    activity_id: String!
+  ): [GarminActivityLap!]!
 
   """
   Retrieve all reverse-geocoded addresses for a Garmin activity (start, mid-route waypoints, and end).

--- a/tests/datasources/OtelDataAPI.test.ts
+++ b/tests/datasources/OtelDataAPI.test.ts
@@ -320,6 +320,7 @@ describe('OtelDataAPI', () => {
     await api.getGarminSports();
     await api.getGarminDeviceCounts();
     await api.getGarminChartData('ga-1');
+    await api.getGarminActivityLaps('ga-1');
     await api.getGarminActivityTotals({ period: 'week' });
     await api.triggerGarminSync({ window_hours: 24 });
     await api.getUnifiedGps({ source: 'gps' });
@@ -349,6 +350,7 @@ describe('OtelDataAPI', () => {
       '/api/v1/garmin/sports',
       '/api/v1/garmin/device-counts',
       '/api/v1/garmin/activities/ga-1/chart-data',
+      '/api/v1/garmin/activities/ga-1/laps',
       '/api/v1/garmin/activity-totals',
       '/api/v1/garmin/sync',
       '/api/v1/gps/unified',

--- a/tests/resolvers/resolvers.test.ts
+++ b/tests/resolvers/resolvers.test.ts
@@ -165,17 +165,20 @@ describe('garmin resolvers', () => {
       getGarminSports: mockAsync(['cycling']),
       getGarminDeviceCounts: mockAsync([{ label: 'Edge 500', activity_count: 2 }]),
       getGarminChartData: mockAsync([{ timestamp: 'now' }]),
+      getGarminActivityLaps: mockAsync([{ activity_id: 'abc', lap_index: 1 }]),
     });
 
     await runResolver(garminResolvers.Query.garminActivity, { activity_id: 'abc' }, ctx);
     await runResolver(garminResolvers.Query.garminSports, {}, ctx);
     await runResolver(garminResolvers.Query.garminDeviceCounts, {}, ctx);
     await runResolver(garminResolvers.Query.garminChartData, { activity_id: 'abc' }, ctx);
+    await runResolver(garminResolvers.Query.garminActivityLaps, { activity_id: 'abc' }, ctx);
 
     expect(ctx.dataSources.otelAPI.getGarminActivity).toHaveBeenCalledWith('abc');
     expect(ctx.dataSources.otelAPI.getGarminSports).toHaveBeenCalled();
     expect(ctx.dataSources.otelAPI.getGarminDeviceCounts).toHaveBeenCalled();
     expect(ctx.dataSources.otelAPI.getGarminChartData).toHaveBeenCalledWith('abc');
+    expect(ctx.dataSources.otelAPI.getGarminActivityLaps).toHaveBeenCalledWith('abc');
   });
 
   it('passes device metadata through garminActivity', async () => {

--- a/tests/schema/typeDefs.test.ts
+++ b/tests/schema/typeDefs.test.ts
@@ -176,4 +176,61 @@ describe('typeDefs', () => {
       ],
     });
   });
+
+  it('exposes Garmin activity laps', async () => {
+    const schema = buildSchema(typeDefs);
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          garminActivityLaps(activity_id: "activity-1") {
+            activity_id
+            lap_index
+            duration_seconds
+            distance_meters
+            paved_distance_meters
+            unpaved_distance_meters
+            avg_speed_mps
+            avg_heart_rate
+            max_heart_rate
+            total_ascent_meters
+          }
+        }
+      `,
+      rootValue: {
+        garminActivityLaps: () => [
+          {
+            activity_id: 'activity-1',
+            lap_index: 1,
+            duration_seconds: 1637.3,
+            distance_meters: 8046.72,
+            paved_distance_meters: 7805.32,
+            unpaved_distance_meters: 241.4,
+            avg_speed_mps: 4.915,
+            avg_heart_rate: 130,
+            max_heart_rate: 150,
+            total_ascent_meters: 30,
+          },
+        ],
+      },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      garminActivityLaps: [
+        {
+          activity_id: 'activity-1',
+          lap_index: 1,
+          duration_seconds: 1637.3,
+          distance_meters: 8046.72,
+          paved_distance_meters: 7805.32,
+          unpaved_distance_meters: 241.4,
+          avg_speed_mps: 4.915,
+          avg_heart_rate: 130,
+          max_heart_rate: 150,
+          total_ascent_meters: 30,
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add `GarminActivityLap` to the GraphQL schema and generated gateway types
- add `garminActivityLaps(activity_id: String!)` resolver support
- call the API laps endpoint with the same short cache TTL pattern used by chart/climb data
- add datasource, resolver, and schema coverage for the new query

Tracks #149.

## Validation
- `npm run test -- --runInBand --silent`
- `npm run type-check`
- `npm run lint:all`
- `npm run build`
- pre-push `npm run lint:spell` and detect-secrets scan

## Notes
- Built on `master` after the `@stuartshay/otel-data-types@1.0.506` update was merged.
- After merge, validate that the gateway types package publishes before starting the UI dependency update.