### PR TITLE
[codex] Fix ready database GraphQL payload

### DIFF
--- a/packages/graphql-types/index.d.ts
+++ b/packages/graphql-types/index.d.ts
@@ -942,8 +942,8 @@ export interface QueryWithinReferenceArgs {
 /** Service readiness status including database connectivity. */
 export interface ReadyStatus {
   __typename?: 'ReadyStatus';
-  /** Database connection status */
-  database?: Maybe<Scalars['String']['output']>;
+  /** Database readiness payload returned by otel-data-api */
+  database?: Maybe<Scalars['JSON']['output']>;
   /** Service readiness status */
   status: Scalars['String']['output'];
   /** Application version from VERSION file */

--- a/packages/graphql-types/schema.graphql
+++ b/packages/graphql-types/schema.graphql
@@ -50,9 +50,9 @@ type ReadyStatus {
   """
   status: String!
   """
-  Database connection status
+  Database readiness payload returned by otel-data-api
   """
-  database: String
+  database: JSON
   """
   Application version from VERSION file
   """

--- a/src/__generated__/resolvers-types.ts
+++ b/src/__generated__/resolvers-types.ts
@@ -964,8 +964,8 @@ export type QueryWithinReferenceArgs = {
 /** Service readiness status including database connectivity. */
 export type ReadyStatus = {
   __typename?: 'ReadyStatus';
-  /** Database connection status */
-  database?: Maybe<Scalars['String']['output']>;
+  /** Database readiness payload returned by otel-data-api */
+  database?: Maybe<Scalars['JSON']['output']>;
   /** Service readiness status */
   status: Scalars['String']['output'];
   /** Application version from VERSION file */
@@ -1666,7 +1666,7 @@ export type QueryResolvers<ContextType = GatewayContext, ParentType extends Reso
 }>;
 
 export type ReadyStatusResolvers<ContextType = GatewayContext, ParentType extends ResolversParentTypes['ReadyStatus'] = ResolversParentTypes['ReadyStatus']> = ResolversObject<{
-  database?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  database?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;

--- a/src/datasources/OtelDataAPI.ts
+++ b/src/datasources/OtelDataAPI.ts
@@ -15,6 +15,21 @@ type GarminSyncUpstreamResponse = Schemas['GarminSyncResponse'] & {
   accepted?: boolean | null;
 };
 
+interface UpstreamReadyDatabaseStatus {
+  [key: string]: unknown;
+  status?: string | null;
+  version?: string | null;
+  server_time?: string | null;
+  pool_size?: number | null;
+  pool_free?: number | null;
+}
+
+interface UpstreamReadyStatus {
+  status: string;
+  database?: UpstreamReadyDatabaseStatus | null;
+  version?: string | null;
+}
+
 interface FetchParams {
   path: string;
   query?: Record<string, string | number | boolean | undefined | null>;
@@ -231,7 +246,7 @@ export class OtelDataAPI {
   }
 
   async getReady() {
-    return this.fetch<{ status: string; database?: string; version?: string }>({
+    return this.fetch<UpstreamReadyStatus>({
       path: '/ready',
       timeoutMs: 2_000,
     });

--- a/src/resolvers/health.ts
+++ b/src/resolvers/health.ts
@@ -17,7 +17,9 @@ export const healthResolvers: { Query: Pick<QueryResolvers, 'health' | 'ready'> 
       } catch (error) {
         return {
           status: 'unhealthy',
-          database: error instanceof Error ? error.message : 'unknown error',
+          database: {
+            status: error instanceof Error ? error.message : 'unknown error',
+          },
           version: config.version,
         };
       }

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -50,9 +50,9 @@ type ReadyStatus {
   """
   status: String!
   """
-  Database connection status
+  Database readiness payload returned by otel-data-api
   """
-  database: String
+  database: JSON
   """
   Application version from VERSION file
   """

--- a/tests/resolvers/resolvers.test.ts
+++ b/tests/resolvers/resolvers.test.ts
@@ -56,7 +56,17 @@ describe('health resolvers', () => {
   });
 
   it('returns readiness result when backend responds', async () => {
-    const result = { status: 'ready', database: 'ok', version: '1.2.3' };
+    const result = {
+      status: 'ready',
+      database: {
+        status: 'healthy',
+        version: 'PostgreSQL 15.3',
+        server_time: '2026-07-04 02:38:48.710129+00:00',
+        pool_size: 2,
+        pool_free: 2,
+      },
+      version: '1.2.3',
+    };
     const ctx = contextWith({ getReady: mockAsync(result) });
 
     const response = await runResolver(healthResolvers.Query.ready, {}, ctx);
@@ -72,7 +82,9 @@ describe('health resolvers', () => {
 
     expect(response).toEqual({
       status: 'unhealthy',
-      database: 'database down',
+      database: {
+        status: 'database down',
+      },
       version: config.version,
     });
   });

--- a/tests/schema/typeDefs.test.ts
+++ b/tests/schema/typeDefs.test.ts
@@ -12,6 +12,50 @@ describe('typeDefs', () => {
     expect(typeDefs).toContain('total_strokes: Int');
   });
 
+  it('exposes structured readiness database status', async () => {
+    const schema = buildSchema(typeDefs);
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          ready {
+            status
+            version
+            database
+          }
+        }
+      `,
+      rootValue: {
+        ready: () => ({
+          status: 'ready',
+          version: '1.0.501',
+          database: {
+            status: 'healthy',
+            version: 'PostgreSQL 15.3',
+            server_time: '2026-07-04 02:38:48.710129+00:00',
+            pool_size: 2,
+            pool_free: 2,
+          },
+        }),
+      },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      ready: {
+        status: 'ready',
+        version: '1.0.501',
+        database: {
+          status: 'healthy',
+          version: 'PostgreSQL 15.3',
+          server_time: '2026-07-04 02:38:48.710129+00:00',
+          pool_size: 2,
+          pool_free: 2,
+        },
+      },
+    });
+  });
+
   it('exposes heart-rate zone and respiration rate on Garmin chart points', async () => {
     const schema = buildSchema(typeDefs);
     const result = await graphql({


### PR DESCRIPTION
## Summary
- change `ReadyStatus.database` from `String` to the existing `JSON` scalar so the gateway can return the current `otel-data-api` readiness database object
- update the readiness fallback resolver to return a JSON-compatible database payload on failures
- regenerate gateway resolver/package types
- add resolver and schema tests for the structured readiness database payload

Refs #151.

## Validation
- `npm run lint:all`
- `npm run type-check`
- `npm run test -- --runInBand --silent`
- `npm run build`
- pre-push `npm run lint:spell` and detect-secrets scan

## Notes
This preserves the original query shape that failed in production:

```graphql
{
  health { status version }
  ready { status database version }
}
```

The `database` field now serializes the API object instead of trying to coerce it to a string.
